### PR TITLE
RunInstances, CreateImage: specify block device mappings

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -443,8 +443,9 @@ func (ec2 *EC2) Instances(instIds []string, filter *Filter) (resp *InstancesResp
 type CreateImage struct {
 	InstanceId          string
 	Name                string
+	Description         string
+	NoReboot            bool
 	BlockDeviceMappings []BlockDeviceMapping
-	// TODO: Description, NoReboot
 }
 
 // Response to a CreateImage request.
@@ -520,6 +521,12 @@ func (ec2 *EC2) CreateImage(options *CreateImage) (resp *CreateImageResp, err er
 	params := makeParams("CreateImage")
 	params["InstanceId"] = options.InstanceId
 	params["Name"] = options.Name
+	if options.Description != "" {
+		params["Description"] = options.Description
+	}
+	if options.NoReboot {
+		params["NoReboot"] = "true"
+	}
 	for i, bdm := range options.BlockDeviceMappings {
 		if bdm.DeviceName != "" {
 			params["BlockDeviceMapping."+strconv.Itoa(i+1)+".DeviceName"] = bdm.DeviceName

--- a/ec2/ec2_test.go
+++ b/ec2/ec2_test.go
@@ -265,8 +265,10 @@ func (s *S) TestCreateImageExample(c *C) {
 	testServer.Response(200, nil, CreateImageExample)
 
 	options := &ec2.CreateImage{
-		InstanceId: "i-123456",
-		Name:       "foo",
+		InstanceId:  "i-123456",
+		Name:        "foo",
+		Description: "goamz test",
+		NoReboot:    true,
 		BlockDeviceMappings: []ec2.BlockDeviceMapping{
 			{DeviceName: "/dev/sdb", VirtualName: "ephemeral0"},
 			{DeviceName: "/dev/sdc", VirtualName: "ephemeral1"}},
@@ -278,6 +280,8 @@ func (s *S) TestCreateImageExample(c *C) {
 	c.Assert(req.Form["Action"], DeepEquals, []string{"CreateImage"})
 	c.Assert(req.Form["InstanceId"], DeepEquals, []string{options.InstanceId})
 	c.Assert(req.Form["Name"], DeepEquals, []string{options.Name})
+	c.Assert(req.Form["Description"], DeepEquals, []string{options.Description})
+	c.Assert(req.Form["NoReboot"], DeepEquals, []string{"true"})
 	c.Assert(req.Form["BlockDeviceMapping.1.DeviceName"], DeepEquals, []string{"/dev/sdb"})
 	c.Assert(req.Form["BlockDeviceMapping.1.VirtualName"], DeepEquals, []string{"ephemeral0"})
 	c.Assert(req.Form["BlockDeviceMapping.2.DeviceName"], DeepEquals, []string{"/dev/sdc"})


### PR DESCRIPTION
Having some trouble running tests:

```
$ go test
warning: building out-of-date packages:
    github.com/mitchellh/goamz/ec2/ec2test
    github.com/mitchellh/goamz/testutil
installing these packages with 'go test -i' will speed future tests.

# _/Users/rgarcia/github/goamz/ec2_test
./ec2_test.go:97: unknown ec2.RunInstances field 'BlockDeviceMappings' in struct literal
./ec2_test.go:729: undefined: ec2.FakeTime
./ec2_test.go:730: undefined: ec2.FakeTime
./ec2_test.go:730: defer requires function call, not conversion
./sign_test.go:15: undefined: ec2.Sign
./sign_test.go:28: undefined: ec2.Sign
./sign_test.go:46: undefined: ec2.Sign
./sign_test.go:53: undefined: ec2.Sign
./sign_test.go:65: undefined: ec2.Sign
FAIL    _/Users/rgarcia/github/goamz/ec2 [build failed]
```
