### PR TITLE
Add BlockDeviceMapping to CreateImage and RunInstances

### DIFF
--- a/ec2/ec2_test.go
+++ b/ec2/ec2_test.go
@@ -92,6 +92,10 @@ func (s *S) TestRunInstancesExample(c *C) {
 		DisableAPITermination: true,
 		ShutdownBehavior:      "terminate",
 		PrivateIPAddress:      "10.0.0.25",
+		BlockDevices: []ec2.BlockDeviceMapping{
+			{DeviceName: "/dev/sdb", VirtualName: "ephemeral0"},
+			{DeviceName: "/dev/sdc", SnapshotId: "snap-a08912c9", DeleteOnTermination: true},
+		},
 	}
 	resp, err := s.ec2.RunInstances(&options)
 
@@ -116,6 +120,10 @@ func (s *S) TestRunInstancesExample(c *C) {
 	c.Assert(req.Form["DisableApiTermination"], DeepEquals, []string{"true"})
 	c.Assert(req.Form["InstanceInitiatedShutdownBehavior"], DeepEquals, []string{"terminate"})
 	c.Assert(req.Form["PrivateIpAddress"], DeepEquals, []string{"10.0.0.25"})
+	c.Assert(req.Form["BlockDeviceMapping.1.DeviceName"], DeepEquals, []string{"/dev/sdb"})
+	c.Assert(req.Form["BlockDeviceMapping.1.VirtualName"], DeepEquals, []string{"ephemeral0"})
+	c.Assert(req.Form["BlockDeviceMapping.2.Ebs.SnapshotId"], DeepEquals, []string{"snap-a08912c9"})
+	c.Assert(req.Form["BlockDeviceMapping.2.Ebs.DeleteOnTermination"], DeepEquals, []string{"true"})
 
 	c.Assert(err, IsNil)
 	c.Assert(resp.RequestId, Equals, "59dbff89-35bd-4eac-99ed-be587EXAMPLE")
@@ -258,8 +266,14 @@ func (s *S) TestCreateImageExample(c *C) {
 	testServer.Response(200, nil, CreateImageExample)
 
 	options := &ec2.CreateImage{
-		InstanceId: "i-123456",
-		Name:       "foo",
+		InstanceId:  "i-123456",
+		Name:        "foo",
+		Description: "Test CreateImage",
+		NoReboot:    true,
+		BlockDevices: []ec2.BlockDeviceMapping{
+			{DeviceName: "/dev/sdb", VirtualName: "ephemeral0"},
+			{DeviceName: "/dev/sdc", SnapshotId: "snap-a08912c9", DeleteOnTermination: true},
+		},
 	}
 
 	resp, err := s.ec2.CreateImage(options)
@@ -268,6 +282,13 @@ func (s *S) TestCreateImageExample(c *C) {
 	c.Assert(req.Form["Action"], DeepEquals, []string{"CreateImage"})
 	c.Assert(req.Form["InstanceId"], DeepEquals, []string{options.InstanceId})
 	c.Assert(req.Form["Name"], DeepEquals, []string{options.Name})
+	c.Assert(req.Form["Description"], DeepEquals, []string{options.Description})
+	c.Assert(req.Form["NoReboot"], DeepEquals, []string{"true"})
+	c.Assert(req.Form["BlockDeviceMapping.1.DeviceName"], DeepEquals, []string{"/dev/sdb"})
+	c.Assert(req.Form["BlockDeviceMapping.1.VirtualName"], DeepEquals, []string{"ephemeral0"})
+	c.Assert(req.Form["BlockDeviceMapping.2.DeviceName"], DeepEquals, []string{"/dev/sdc"})
+	c.Assert(req.Form["BlockDeviceMapping.2.Ebs.SnapshotId"], DeepEquals, []string{"snap-a08912c9"})
+	c.Assert(req.Form["BlockDeviceMapping.2.Ebs.DeleteOnTermination"], DeepEquals, []string{"true"})
 
 	c.Assert(err, IsNil)
 	c.Assert(resp.RequestId, Equals, "59dbff89-35bd-4eac-99ed-be587EXAMPLE")
@@ -731,5 +752,5 @@ func (s *S) TestSignatureWithEndpointPath(c *C) {
 	c.Assert(err, IsNil)
 
 	req := testServer.WaitRequest()
-	c.Assert(req.Form["Signature"], DeepEquals, []string{"gdG/vEm+c6ehhhfkrJy3+wuVzw/rzKR42TYelMwti7M="})
+	c.Assert(req.Form["Signature"], DeepEquals, []string{"klxs+VwDa1EKHBsxlDYYN58wbP6An+RVdhETv1Fm/os="})
 }


### PR DESCRIPTION
This change add BlockDeviceMapping to CreateImage and RunInstances. While
testing against AWS the error "The parameter BlockDeviceMapping is not
recognized" was occurring until the Version was changed to a more recent
API version.
