### PR TITLE
CreateSecurityGroup: take in VPC ID

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -271,6 +271,9 @@ type Instance struct {
 	PlacementGroupName string        `xml:"placement>groupName"`
 	State              InstanceState `xml:"instanceState"`
 	Tags               []Tag         `xml:"tagSet>item"`
+	VpcId              string        `xml:"vpcId"`
+	SubnetId           string        `xml:"subnetId"`
+	PrivateIpAddress   string        `xml:"privateIpAddress"`
 }
 
 // RunInstances starts new instances in EC2.
@@ -734,17 +737,20 @@ type CreateSecurityGroupResp struct {
 // name and description.
 //
 // See http://goo.gl/Eo7Yl for more details.
-func (ec2 *EC2) CreateSecurityGroup(name, description string) (resp *CreateSecurityGroupResp, err error) {
+func (ec2 *EC2) CreateSecurityGroup(group SecurityGroup) (resp *CreateSecurityGroupResp, err error) {
 	params := makeParams("CreateSecurityGroup")
-	params["GroupName"] = name
-	params["GroupDescription"] = description
+	params["GroupName"] = group.Name
+	params["GroupDescription"] = group.Description
+	if group.VpcId != "" {
+		params["VpcId"] = group.VpcId
+	}
 
 	resp = &CreateSecurityGroupResp{}
 	err = ec2.query(params, resp)
 	if err != nil {
 		return nil, err
 	}
-	resp.Name = name
+	resp.Name = group.Name
 	return resp, nil
 }
 
@@ -790,8 +796,10 @@ type UserSecurityGroup struct {
 // If SecurityGroup is used as a parameter, then one of Id or Name
 // may be empty. If both are set, then Id is used.
 type SecurityGroup struct {
-	Id   string `xml:"groupId"`
-	Name string `xml:"groupName"`
+	Id          string `xml:"groupId"`
+	Name        string `xml:"groupName"`
+	Description string `xml:"groupDescription"`
+	VpcId       string `xml:"vpcId"`
 }
 
 // SecurityGroupNames is a convenience function that

--- a/ec2/ec2_test.go
+++ b/ec2/ec2_test.go
@@ -448,7 +448,7 @@ func (s *S) TestDeleteKeyPairExample(c *C) {
 func (s *S) TestCreateSecurityGroupExample(c *C) {
 	testServer.Response(200, nil, CreateSecurityGroupExample)
 
-	resp, err := s.ec2.CreateSecurityGroup("websrv", "Web Servers")
+	resp, err := s.ec2.CreateSecurityGroup(ec2.SecurityGroup{Name: "websrv", Description: "Web Servers"})
 
 	req := testServer.WaitRequest()
 	c.Assert(req.Form["Action"], DeepEquals, []string{"CreateSecurityGroup"})

--- a/ec2/ec2i_test.go
+++ b/ec2/ec2i_test.go
@@ -107,13 +107,13 @@ func (s *ClientTests) TestSecurityGroups(c *C) {
 	s.ec2.DeleteSecurityGroup(ec2.SecurityGroup{Name: name})
 	defer s.ec2.DeleteSecurityGroup(ec2.SecurityGroup{Name: name})
 
-	resp1, err := s.ec2.CreateSecurityGroup(name, descr)
+	resp1, err := s.ec2.CreateSecurityGroup(ec2.SecurityGroup{Name: name, Description: descr})
 	c.Assert(err, IsNil)
 	c.Assert(resp1.RequestId, Matches, ".+")
 	c.Assert(resp1.Name, Equals, name)
 	c.Assert(resp1.Id, Matches, ".+")
 
-	resp1, err = s.ec2.CreateSecurityGroup(name, descr)
+	resp1, err = s.ec2.CreateSecurityGroup(ec2.SecurityGroup{Name: name, Description: descr})
 	ec2err, _ := err.(*ec2.Error)
 	c.Assert(resp1, IsNil)
 	c.Assert(ec2err, NotNil)

--- a/ec2/ec2t_test.go
+++ b/ec2/ec2t_test.go
@@ -122,7 +122,7 @@ func (s *ServerTests) makeTestGroup(c *C, name, descr string) ec2.SecurityGroup 
 		c.Fatalf("delete security group: %v", err)
 	}
 
-	resp, err := s.ec2.CreateSecurityGroup(name, descr)
+	resp, err := s.ec2.CreateSecurityGroup(ec2.SecurityGroup{Name: name, Description: descr})
 	c.Assert(err, IsNil)
 	c.Assert(resp.Name, Equals, name)
 	return resp.SecurityGroup
@@ -250,7 +250,7 @@ func (s *ServerTests) TestDuplicateIPPerm(c *C) {
 	s.ec2.DeleteSecurityGroup(ec2.SecurityGroup{Name: name})
 	defer s.ec2.DeleteSecurityGroup(ec2.SecurityGroup{Name: name})
 
-	resp1, err := s.ec2.CreateSecurityGroup(name, descr)
+	resp1, err := s.ec2.CreateSecurityGroup(ec2.SecurityGroup{Name: name, Description: descr})
 	c.Assert(err, IsNil)
 	c.Assert(resp1.Name, Equals, name)
 
@@ -279,12 +279,12 @@ type filterSpec struct {
 }
 
 func (s *ServerTests) TestInstanceFiltering(c *C) {
-	groupResp, err := s.ec2.CreateSecurityGroup(sessionName("testgroup1"), "testgroup one description")
+	groupResp, err := s.ec2.CreateSecurityGroup(ec2.SecurityGroup{Name: sessionName("testgroup1"), Description: "testgroup one description"})
 	c.Assert(err, IsNil)
 	group1 := groupResp.SecurityGroup
 	defer s.ec2.DeleteSecurityGroup(group1)
 
-	groupResp, err = s.ec2.CreateSecurityGroup(sessionName("testgroup2"), "testgroup two description")
+	groupResp, err = s.ec2.CreateSecurityGroup(ec2.SecurityGroup{Name: sessionName("testgroup2"), Description: "testgroup two description"})
 	c.Assert(err, IsNil)
 	group2 := groupResp.SecurityGroup
 	defer s.ec2.DeleteSecurityGroup(group2)
@@ -437,7 +437,7 @@ func namesOnly(gs []ec2.SecurityGroup) []ec2.SecurityGroup {
 func (s *ServerTests) TestGroupFiltering(c *C) {
 	g := make([]ec2.SecurityGroup, 4)
 	for i := range g {
-		resp, err := s.ec2.CreateSecurityGroup(sessionName(fmt.Sprintf("testgroup%d", i)), fmt.Sprintf("testdescription%d", i))
+		resp, err := s.ec2.CreateSecurityGroup(ec2.SecurityGroup{Name: sessionName(fmt.Sprintf("testgroup%d", i)), Description: fmt.Sprintf("testdescription%d", i)})
 		c.Assert(err, IsNil)
 		g[i] = resp.SecurityGroup
 		c.Logf("group %d: %v", i, g[i])


### PR DESCRIPTION
Changes the signature of CreateSecurityGroup to be more in line with other library functions (and more flexible to change).
