### PR TITLE
ec2: Added DescribeImageAttribute API call

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -634,6 +634,21 @@ type ImagesResp struct {
 	Images    []Image `xml:"imagesSet>item"`
 }
 
+// Response to a DescribeImageAttribute request.
+//
+// See http://goo.gl/bHO3zT for more details.
+type ImageAttributeResp struct {
+	RequestId    string               `xml:"requestId"`
+	ImageId      string               `xml:"imageId"`
+	Kernel       string               `xml:"kernel>value"`
+	RamDisk      string               `xml:"ramdisk>value"`
+	Description  string               `xml:"description>value"`
+	Group        string               `xml:"launchPermission>item>group"`
+	UserIds      []string             `xml:"launchPermission>item>userId"`
+	ProductCodes []string             `xml:"productCodes>item>productCode"`
+	BlockDevices []BlockDeviceMapping `xml:"blockDeviceMapping>item"`
+}
+
 // The RegisterImage request parameters.
 type RegisterImage struct {
 	ImageLocation  string
@@ -773,6 +788,25 @@ func (ec2 *EC2) Images(ids []string, filter *Filter) (resp *ImagesResp, err erro
 	filter.addParams(params)
 
 	resp = &ImagesResp{}
+	err = ec2.query(params, resp)
+	if err != nil {
+		return nil, err
+	}
+	return
+}
+
+// ImageAttribute describes an attribute of an AMI.
+// You can specify only one attribute at a time.
+// Valid attributes are:
+//    description | kernel | ramdisk | launchPermission | productCodes | blockDeviceMapping
+//
+// See http://goo.gl/bHO3zT for more details.
+func (ec2 *EC2) ImageAttribute(imageId, attribute string) (resp *ImageAttributeResp, err error) {
+	params := makeParams("DescribeImageAttribute")
+	params["ImageId"] = imageId
+	params["Attribute"] = attribute
+
+	resp = &ImageAttributeResp{}
 	err = ec2.query(params, resp)
 	if err != nil {
 		return nil, err

--- a/ec2/ec2_test.go
+++ b/ec2/ec2_test.go
@@ -343,6 +343,21 @@ func (s *S) TestDescribeImagesExample(c *C) {
 	c.Assert(i0.BlockDevices[0].DeleteOnTermination, Equals, true)
 }
 
+func (s *S) TestImageAttributeExample(c *C) {
+	testServer.Response(200, nil, ImageAttributeExample)
+
+	resp, err := s.ec2.ImageAttribute("ami-61a54008", "launchPermission")
+
+	req := testServer.WaitRequest()
+	c.Assert(req.Form["Action"], DeepEquals, []string{"DescribeImageAttribute"})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "59dbff89-35bd-4eac-99ed-be587EXAMPLE")
+	c.Assert(resp.ImageId, Equals, "ami-61a54008")
+	c.Assert(resp.Group, Equals, "all")
+	c.Assert(resp.UserIds[0], Equals, "495219933132")
+}
+
 func (s *S) TestCreateSnapshotExample(c *C) {
 	testServer.Response(200, nil, CreateSnapshotExample)
 

--- a/ec2/responses_test.go
+++ b/ec2/responses_test.go
@@ -368,6 +368,22 @@ var DescribeImagesExample = `
 </DescribeImagesResponse>
 `
 
+// http://goo.gl/bHO3z
+var ImageAttributeExample = `
+<DescribeImageAttributeResponse xmlns="http://ec2.amazonaws.com/doc/2013-07-15/">
+   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
+   <imageId>ami-61a54008</imageId>
+   <launchPermission>
+      <item>
+         <group>all</group>
+      </item>
+      <item>
+         <userId>495219933132</userId>
+      </item>
+   </launchPermission>
+</DescribeImageAttributeResponse>
+`
+
 // http://goo.gl/ttcda
 var CreateSnapshotExample = `
 <CreateSnapshotResponse xmlns="http://ec2.amazonaws.com/doc/2012-10-01/">


### PR DESCRIPTION
New API call.

@mitchellh, I originally had this bit of code:

``` go
type LaunchPermission struct {
    Group  string `xml:"group"`
    UserId string `xml:"userId"`
}

type ProductCodes struct {
    ProductCode string `xml:"productCode"`
    Type        string `xml:"type"`
}

type ImageAttributeResp struct {
    RequestId        string               `xml:"requestId"`
    ImageId          string               `xml:"imageId"`
    Kernel           string               `xml:"kernel"`
    RamDisk          string               `xml:"ramdisk"`
    Description      string               `xml:"description"`
    LaunchPermission []LaunchPermission   `xml:"launchPermission>item"`
    ProductCodes     []ProductCodes       `xml:"productCodes>item"`
    BlockDevices     []BlockDeviceMapping `xml:"blockDeviceMapping>item"`
}
```

But it seemed unnecessary.  Regarding LaunchPermission, the only valid group is "all" so it seemed better to just deal with an array of strings for UserIds.  With ProductCodes, the example [here](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeImageAttribute.html) shows a "type" is returned, but the doc [here](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-ItemType-ProductCodeItemType.html) doesn't have it, so again it seemed easier to use an array of strings.  Let me know which you prefer.
