### PR TITLE
Allow custom headers for S3 Put

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -182,19 +182,26 @@ func (b *Bucket) GetResponse(path string) (*http.Response, error) {
 // Put inserts an object into the S3 bucket.
 //
 // See http://goo.gl/FEBPD for details.
-func (b *Bucket) Put(path string, data []byte, contType string, perm ACL) error {
+func (b *Bucket) Put(path string, data []byte, customHeaders map[string][]string, perm ACL) error {
 	body := bytes.NewBuffer(data)
-	return b.PutReader(path, body, int64(len(data)), contType, perm)
+	return b.PutReader(path, body, int64(len(data)), customHeaders, perm)
 }
 
 // PutReader inserts an object into the S3 bucket by consuming data
 // from r until EOF.
-func (b *Bucket) PutReader(path string, r io.Reader, length int64, contType string, perm ACL) error {
+func (b *Bucket) PutReader(path string, r io.Reader, length int64, customHeaders map[string][]string, perm ACL) error {
+	// Default headers
 	headers := map[string][]string{
 		"Content-Length": {strconv.FormatInt(length, 10)},
-		"Content-Type":   {contType},
+		"Content-Type":   {"application/text"},
 		"x-amz-acl":      {string(perm)},
 	}
+
+	// Override with custom headers
+	for key, value := range customHeaders {
+		headers[key] = value
+	}
+
 	req := &request{
 		method:  "PUT",
 		bucket:  b.Name,

--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -163,7 +163,12 @@ func (s *S) TestPutObject(c *C) {
 	testServer.Response(200, nil, "")
 
 	b := s.s3.Bucket("bucket")
-	err := b.Put("name", []byte("content"), "content-type", s3.Private)
+	err := b.Put(
+		"name",
+		[]byte("content"),
+		map[string][]string{"Content-Type": {"content-type"}},
+		s3.Private,
+	)
 	c.Assert(err, IsNil)
 
 	req := testServer.WaitRequest()
@@ -181,7 +186,13 @@ func (s *S) TestPutReader(c *C) {
 
 	b := s.s3.Bucket("bucket")
 	buf := bytes.NewBufferString("content")
-	err := b.PutReader("name", buf, int64(buf.Len()), "content-type", s3.Private)
+	err := b.PutReader(
+		"name",
+		buf,
+		int64(buf.Len()),
+		map[string][]string{"Content-Type": {"content-type"}},
+		s3.Private,
+	)
 	c.Assert(err, IsNil)
 
 	req := testServer.WaitRequest()


### PR DESCRIPTION
- S3.Put should take in custom headers instead of just Content-Type
- Allow custom headers to override default set
  - Default to Content-Type: application/text
