### PR TITLE
AssociatePublicIpAddress support for goamz/packer

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -282,7 +282,7 @@ type Instance struct {
 	SubnetId           string        `xml:"subnetId"`
 	IamInstanceProfile string        `xml:"iamInstanceProfile"`
 	PrivateIpAddress   string        `xml:"privateIpAddress"`
-	PublicIpAddress    string        `xml:"IpAddress"`
+	PublicIpAddress    string        `xml:"ipAddress"`
 	Architecture       string        `xml:"architecture"`
 }
 


### PR DESCRIPTION
Provides required underlying AssociatePublicIpAddress support for goamz, so that packer can use it.

Needed to bump the EC2 API version here, I don't suspect any other breakage looking at their release notes though.

Ignore my testing/revert testing commits, files changed shows the relevant stuff at least.

Relates to https://github.com/mitchellh/packer/issues/578
