### PR TITLE
ec2:AllocateAddress

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -603,6 +603,100 @@ func (ec2 *EC2) Volumes(volIds []string, filter *Filter) (resp *VolumesResp, err
 }
 
 // ----------------------------------------------------------------------------
+// ElasticIp management (for VPC)
+
+// The AllocateAddress request parameters
+//
+// see http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-AllocateAddress.html
+type AllocateAddress struct {
+	Domain string
+}
+
+// Response to an AllocateAddress request
+type AllocateAddressResp struct {
+	RequestId    string `xml:"requestId"`
+	PublicIp     string `xml:"publicIp"`
+	Domain       string `xml:"domain"`
+	AllocationId string `xml:"allocationId"`
+}
+
+// The AssociateAddress request parameters
+//
+// http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-AssociateAddress.html
+type AssociateAddress struct {
+	InstanceId         string
+	AllocationId       string
+	AllowReassociation bool
+}
+
+// Response to an AssociateAddress request
+type AssociateAddressResp struct {
+	RequestId     string `xml:"requestId"`
+	Return        bool   `xml:"return"`
+	AssociationId string `xml:"associationId"`
+}
+
+// Allocate a new Elastic IP.
+func (ec2 *EC2) AllocateAddress(options *AllocateAddress) (resp *AllocateAddressResp, err error) {
+	params := makeParams("AllocateAddress")
+	params["Domain"] = options.Domain
+
+	resp = &AllocateAddressResp{}
+	err = ec2.query(params, resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return
+}
+
+// Release an Elastic IP (VPC).
+func (ec2 *EC2) ReleaseAddress(id string) (resp *SimpleResp, err error) {
+	params := makeParams("ReleaseAddress")
+	params["AllocationId"] = id
+
+	resp = &SimpleResp{}
+	err = ec2.query(params, resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return
+}
+
+// Associate an address with a VPC instance.
+func (ec2 *EC2) AssociateAddress(options *AssociateAddress) (resp *AssociateAddressResp, err error) {
+	params := makeParams("AssociateAddress")
+	params["InstanceId"] = options.InstanceId
+	params["AllocationId"] = options.AllocationId
+	if options.AllowReassociation {
+		params["AllowReassociation"] = "true"
+	}
+
+	resp = &AssociateAddressResp{}
+	err = ec2.query(params, resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return
+}
+
+// Disassociate an address from a VPC instance.
+func (ec2 *EC2) DisassociateAddress(id string) (resp *SimpleResp, err error) {
+	params := makeParams("DisassociateAddress")
+	params["AssociationId"] = id
+
+	resp = &SimpleResp{}
+	err = ec2.query(params, resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return
+}
+
+// ----------------------------------------------------------------------------
 // Image and snapshot management functions and types.
 
 // The CreateImage request parameters.

--- a/ec2/ec2_test.go
+++ b/ec2/ec2_test.go
@@ -829,3 +829,71 @@ func (s *S) TestSignatureWithEndpointPath(c *C) {
 	req := testServer.WaitRequest()
 	c.Assert(req.Form["Signature"], DeepEquals, []string{"klxs+VwDa1EKHBsxlDYYN58wbP6An+RVdhETv1Fm/os="})
 }
+
+func (s *S) TestAllocateAddressExample(c *C) {
+	testServer.Response(200, nil, AllocateAddressExample)
+
+	options := &ec2.AllocateAddress{
+		Domain: "vpc",
+	}
+
+	resp, err := s.ec2.AllocateAddress(options)
+
+	req := testServer.WaitRequest()
+	c.Assert(req.Form["Action"], DeepEquals, []string{"AllocateAddress"})
+	c.Assert(req.Form["Domain"], DeepEquals, []string{"vpc"})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "59dbff89-35bd-4eac-99ed-be587EXAMPLE")
+	c.Assert(resp.PublicIp, Equals, "198.51.100.1")
+	c.Assert(resp.Domain, Equals, "vpc")
+	c.Assert(resp.AllocationId, Equals, "eipalloc-5723d13e")
+}
+
+func (s *S) TestReleaseAddressExample(c *C) {
+	testServer.Response(200, nil, ReleaseAddressExample)
+
+	resp, err := s.ec2.ReleaseAddress("eipalloc-5723d13e")
+
+	req := testServer.WaitRequest()
+	c.Assert(req.Form["Action"], DeepEquals, []string{"ReleaseAddress"})
+	c.Assert(req.Form["AllocationId"], DeepEquals, []string{"eipalloc-5723d13e"})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "59dbff89-35bd-4eac-99ed-be587EXAMPLE")
+}
+
+func (s *S) TestAssociateAddressExample(c *C) {
+	testServer.Response(200, nil, AssociateAddressExample)
+
+	options := &ec2.AssociateAddress{
+        InstanceId: "i-4fd2431a",
+        AllocationId: "eipalloc-5723d13e",
+        AllowReassociation: true,
+	}
+
+	resp, err := s.ec2.AssociateAddress(options)
+
+	req := testServer.WaitRequest()
+	c.Assert(req.Form["Action"], DeepEquals, []string{"AssociateAddress"})
+	c.Assert(req.Form["InstanceId"], DeepEquals, []string{"i-4fd2431a"})
+	c.Assert(req.Form["AllocationId"], DeepEquals, []string{"eipalloc-5723d13e"})
+	c.Assert(req.Form["AllowReassociation"], DeepEquals, []string{"true"})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "59dbff89-35bd-4eac-99ed-be587EXAMPLE")
+	c.Assert(resp.AssociationId, Equals, "eipassoc-fc5ca095")
+}
+
+func (s *S) TestDisassociateAddressExample(c *C) {
+	testServer.Response(200, nil, DisassociateAddressExample)
+
+	resp, err := s.ec2.DisassociateAddress("eipassoc-aa7486c3")
+
+	req := testServer.WaitRequest()
+	c.Assert(req.Form["Action"], DeepEquals, []string{"DisassociateAddress"})
+	c.Assert(req.Form["AssociationId"], DeepEquals, []string{"eipassoc-aa7486c3"})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "59dbff89-35bd-4eac-99ed-be587EXAMPLE")
+}

--- a/ec2/responses_test.go
+++ b/ec2/responses_test.go
@@ -656,3 +656,38 @@ var RebootInstancesExample = `
   <return>true</return>
 </RebootInstancesResponse>
 `
+
+// http://goo.gl/9rprDN
+var AllocateAddressExample = `
+<AllocateAddressResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
+   <publicIp>198.51.100.1</publicIp>
+   <domain>vpc</domain>
+   <allocationId>eipalloc-5723d13e</allocationId>
+</AllocateAddressResponse>
+`
+
+// http://goo.gl/3Q0oCc
+var ReleaseAddressExample = `
+<ReleaseAddressResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
+   <return>true</return>
+</ReleaseAddressResponse>
+`
+
+// http://goo.gl/uOSQE
+var AssociateAddressExample = `
+<AssociateAddressResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
+   <return>true</return>
+   <associationId>eipassoc-fc5ca095</associationId>
+</AssociateAddressResponse>
+`
+
+// http://goo.gl/LrOa0
+var DisassociateAddressExample = `
+<DisassociateAddressResponse xmlns="http://ec2.amazonaws.com/doc/2013-10-15/">
+   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
+   <return>true</return>
+</DisassociateAddressResponse>
+`


### PR DESCRIPTION
I've added some functions for allocating and associating elastic IPs (and disassociating and releasing).

I've been a bit lazy and it only applies to VPC instances (not EC2-Classic), but I don't think it's much needed for EC2-Classic.

I needed this for an addition I made to packer so it could get into my VPC instances to provision them. If you're happy I can submit a pull-request for that too. Having said that, I'm under the impression that packer will SSH into the AWS instance using either the DNSName (on ec2 classic) or the private IP on VPC (assuming that a VPN is set up). So I thought this would save setting up a VPN. Is that right? See https://github.com/sorohan/packer/compare/allocate_elasticip_patch.
