### PR TITLE
ec2: Add VirtType parameter to RegisterImage

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -779,6 +779,7 @@ type RegisterImage struct {
 	KernelId       string
 	RamdiskId      string
 	RootDeviceName string
+	VirtType       string
 	BlockDevices   []BlockDeviceMapping
 }
 
@@ -1016,6 +1017,10 @@ func (ec2 *EC2) RegisterImage(options *RegisterImage) (resp *RegisterImageResp, 
 
 	if options.RootDeviceName != "" {
 		params["RootDeviceName"] = options.RootDeviceName
+	}
+
+	if options.VirtType != "" {
+		params["VirtualizationType"] = options.VirtType
 	}
 
 	addBlockDeviceParams(params, options.BlockDevices)


### PR DESCRIPTION
It's now possible to create instance-store HVM AMIs:

```
http://sorcery.smugmug.com/2014/01/29/instance-store-hvm-amis-for-amazon-ec2/
```

This is controlled by a new optional parameter `VirtType` to
`RegisterImage`, which must be either `paravirtual` or `hvm`.
