### PR TITLE
Adding tags to the DescribeVolumes response

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -532,6 +532,7 @@ type Volume struct {
 	Attachments []VolumeAttachment `xml:"attachmentSet>item"`
 	VolumeType  string             `xml:"volumeType"`
 	IOPS        int64              `xml:"iops"`
+	Tags        []Tag              `xml:"tagSet>item"`
 }
 
 type VolumeAttachment struct {


### PR DESCRIPTION
@mitchellh

Somehow this was lost in the latest commits.  Here it is again. Thanks!
