### PR TITLE
Include x-amz-security-token in s3 during signing

### DIFF
--- a/s3/sign.go
+++ b/s3/sign.go
@@ -41,6 +41,12 @@ func sign(auth aws.Auth, method, canonicalPath string, params, headers map[strin
 	var md5, ctype, date, xamz string
 	var xamzDate bool
 	var sarray []string
+
+	// add security token
+	if auth.Token != "" {
+		headers["x-amz-security-token"] = []string{auth.Token}
+	}
+
 	for k, v := range headers {
 		k = strings.ToLower(k)
 		switch k {

--- a/s3/sign_test.go
+++ b/s3/sign_test.go
@@ -130,3 +130,22 @@ func (s *S) TestSignExampleUnicodeKeys(c *C) {
 	expected := "AWS 0PN5J17HBGZHT7JJ3X82:dxhSBHoI6eVSPcXJqEghlUzZMnY="
 	c.Assert(headers["Authorization"], DeepEquals, []string{expected})
 }
+
+// Not included in AWS documentation
+
+func (s *S) TestSignWithIAMToken(c *C) {
+	method := "GET"
+	path := "/"
+	headers := map[string][]string{
+		"Host": {"s3.amazonaws.com"},
+		"Date": {"Wed, 28 Mar 2007 01:29:59 +0000"},
+	}
+
+	authWithToken := testAuth
+	authWithToken.Token = "totallysecret"
+
+	s3.Sign(authWithToken, method, path, nil, headers)
+	expected := "AWS 0PN5J17HBGZHT7JJ3X82:SJ0yQO7NpHyXJ7zkxY+/fGQ6aUw="
+	c.Assert(headers["Authorization"], DeepEquals, []string{expected})
+	c.Assert(headers["x-amz-security-token"], DeepEquals, []string{authWithToken.Token})
+}


### PR DESCRIPTION
To quote the documentation:

```
If you are signing your request using temporary security credentials (see Making Requests),
you must include the corresponding security token in your request by adding the
x-amz-security-token header.
```

It wasn't included in headers before, and s3 couldn't be accessed with
the temporary token. Luckily this commit fixes that.
