### PR TITLE
do not close response until buildError finishes

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -554,7 +554,7 @@ func (s3 *S3) run(req *request, resp interface{}) (*http.Response, error) {
 		log.Printf("} -> %s\n", dump)
 	}
 	if hresp.StatusCode != 200 && hresp.StatusCode != 204 {
-		hresp.Body.Close()
+		defer hresp.Body.Close()
 		return nil, buildError(hresp)
 	}
 	if resp != nil {


### PR DESCRIPTION
`s3_test#TestGetNotFound` failed because `run` tries to decode `hresp.Body`, but
the body's already closed. This patch defers `hresp.Body.Close()` until it
finishes building the error.
