### PR TITLE
add bucket.GetKey to get metadata of a key

### DIFF
--- a/s3/responses_test.go
+++ b/s3/responses_test.go
@@ -196,3 +196,14 @@ var InternalErrorDump = `
   <HostId>kjhwqk</HostId>
 </Error>
 `
+
+var GetKeyHeaderDump = map[string]string{
+	"x-amz-id-2":       "ef8yU9AS1ed4OpIszj7UDNEHGran",
+	"x-amz-request-id": "318BC8BC143432E5",
+	"x-amz-version-id": "3HL4kqtJlcpXroDTDmjVBH40Nrjfkd",
+	"Date":             "Wed, 28 Oct 2009 22:32:00 GMT",
+	"Last-Modified":    "Sun, 1 Jan 2006 12:00:00 GMT",
+	"ETag":             "fba9dede5f27731c9771645a39863328",
+	"Content-Length":   "434234",
+	"Content-Type":     "text/plain",
+}

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -388,6 +388,41 @@ func (b *Bucket) GetBucketContents() (*map[string]Key, error) {
 	return &bucket_contents, nil
 }
 
+// Get metadata from the key without returning the key content
+func (b *Bucket) GetKey(path string) (*Key, error) {
+	req := &request{
+		bucket: b.Name,
+		path:   path,
+		method: "HEAD",
+	}
+	err := b.S3.prepare(req)
+	if err != nil {
+		return nil, err
+	}
+	key := &Key{}
+	for attempt := attempts.Start(); attempt.Next(); {
+		resp, err := b.S3.run(req, nil)
+		if shouldRetry(err) && attempt.HasNext() {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		key.Key = path
+		key.LastModified = resp.Header.Get("Last-Modified")
+		key.ETag = resp.Header.Get("ETag")
+		contentLength := resp.Header.Get("Content-Length")
+		size, err := strconv.ParseInt(contentLength, 10, 64)
+		if err != nil {
+			return key, fmt.Errorf("bad s3 content-length %v: %v",
+				contentLength, err)
+		}
+		key.Size = size
+		return key, nil
+	}
+	panic("unreachable")
+}
+
 // URL returns a non-signed URL that allows retriving the
 // object at path. It only works if the object is publicly
 // readable (see SignedURL).

--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -321,3 +321,21 @@ func (s *S) TestListWithDelimiter(c *C) {
 	c.Assert(len(data.Contents), Equals, 0)
 	c.Assert(data.CommonPrefixes, DeepEquals, []string{"photos/2006/feb/", "photos/2006/jan/"})
 }
+
+func (s *S) TestGetKey(c *C) {
+	testServer.Response(200, GetKeyHeaderDump, "")
+
+	b := s.s3.Bucket("bucket")
+	key, err := b.GetKey("name")
+
+	req := testServer.WaitRequest()
+	c.Assert(req.Method, Equals, "HEAD")
+	c.Assert(req.URL.Path, Equals, "/bucket/name")
+	c.Assert(req.Header["Date"], Not(Equals), "")
+
+	c.Assert(err, IsNil)
+	c.Assert(key.Key, Equals, "name")
+	c.Assert(key.LastModified, Equals, GetKeyHeaderDump["Last-Modified"])
+	c.Assert(key.Size, Equals, int64(434234))
+	c.Assert(key.ETag, Equals, GetKeyHeaderDump["ETag"])
+}


### PR DESCRIPTION
add support for http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectHEAD.html
