### PR TITLE
Unbound version of s3 GetBucketContents

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -365,14 +365,12 @@ func (b *Bucket) List(prefix, delim, marker string, max int) (result *ListResp, 
 }
 
 func (b *Bucket) GetBucketContents() (*map[string]Key, error) {
-	return GetBucketContentsWithPrefix("")
+	return b.GetBucketContentsFiltered("", "", "")
 }
 
 // Returns a mapping of all key names in this bucket to Key objects
-func (b *Bucket) GetBucketContentsWithPrefix(prefix string) (*map[string]Key, error) {
+func (b *Bucket) GetBucketContentsFiltered(prefix, path_separator, marker string) (*map[string]Key, error) {
 	bucket_contents := map[string]Key{}
-	path_separator := ""
-	marker := ""
 	for {
 		contents, err := b.List(prefix, path_separator, marker, 1000)
 		if err != nil {


### PR DESCRIPTION
The normal version of GetBucketContents binds prefix, path_separator and marker to "". This version allows us to specify these.

The name of the new method is crappy, but its in the name of not breaking the API.
