### PR TITLE
add the support for spot instances

### DIFF
--- a/ec2/responses_test.go
+++ b/ec2/responses_test.go
@@ -96,6 +96,84 @@ var RunInstancesExample = `
 </RunInstancesResponse>
 `
 
+// http://goo.gl/GRZgCD
+var RequestSpotInstancesExample = `
+<RequestSpotInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2014-02-01/">
+  <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
+  <spotInstanceRequestSet>
+    <item>
+      <spotInstanceRequestId>sir-1a2b3c4d</spotInstanceRequestId>
+      <spotPrice>0.5</spotPrice>
+      <type>one-time</type>
+      <state>open</state>
+      <status>
+        <code>pending-evaluation</code>
+        <updateTime>YYYY-MM-DDTHH:MM:SS.000Z</updateTime>
+        <message>Your Spot request has been submitted for review, and is pending evaluation.</message>
+      </status>
+      <availabilityZoneGroup>MyAzGroup</availabilityZoneGroup>
+      <launchSpecification>
+        <imageId>ami-1a2b3c4d</imageId>
+        <keyName>gsg-keypair</keyName>
+        <groupSet>
+          <item>
+            <groupId>sg-1a2b3c4d</groupId>
+            <groupName>websrv</groupName>
+          </item>
+        </groupSet>
+        <instanceType>m1.small</instanceType>
+        <blockDeviceMapping/>
+        <monitoring>
+          <enabled>false</enabled>
+        </monitoring>
+        <ebsOptimized>false</ebsOptimized>
+      </launchSpecification>
+      <createTime>YYYY-MM-DDTHH:MM:SS.000Z</createTime>
+      <productDescription>Linux/UNIX</productDescription>
+    </item>
+ </spotInstanceRequestSet>
+</RequestSpotInstancesResponse>
+`
+
+// http://goo.gl/KsKJJk
+var DescribeSpotRequestsExample = `
+<DescribeSpotInstanceRequestsResponse xmlns="http://ec2.amazonaws.com/doc/2014-02-01/">
+  <requestId>b1719f2a-5334-4479-b2f1-26926EXAMPLE</requestId>
+  <spotInstanceRequestSet>
+    <item>
+      <spotInstanceRequestId>sir-1a2b3c4d</spotInstanceRequestId>
+      <spotPrice>0.5</spotPrice>
+      <type>one-time</type>
+      <state>active</state>
+      <status>
+        <code>fulfilled</code>
+        <updateTime>YYYY-MM-DDTHH:MM:SS.000Z</updateTime>
+        <message>Your Spot request is fulfilled.</message>
+      </status>
+      <launchSpecification>
+        <imageId>ami-1a2b3c4d</imageId>
+        <keyName>gsg-keypair</keyName>
+        <groupSet>
+          <item>
+            <groupId>sg-1a2b3c4d</groupId>
+            <groupName>websrv</groupName>
+          </item>
+        </groupSet>
+        <instanceType>m1.small</instanceType>
+        <monitoring>
+          <enabled>false</enabled>
+        </monitoring>
+        <ebsOptimized>false</ebsOptimized>
+      </launchSpecification>
+      <instanceId>i-1a2b3c4d</instanceId>
+      <createTime>YYYY-MM-DDTHH:MM:SS.000Z</createTime>
+      <productDescription>Linux/UNIX</productDescription>
+      <launchedAvailabilityZone>us-east-1a</launchedAvailabilityZone>
+    </item>
+  </spotInstanceRequestSet>
+</DescribeSpotInstanceRequestsResponse>
+`
+
 // http://goo.gl/3BKHj
 var TerminateInstancesExample = `
 <TerminateInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2011-12-15/">


### PR DESCRIPTION
Hi, 

I have done the scripts to support these two APIs for spot instances also with some tests.
- RequestSpotInstances
- DescribeSpotInstanceRequests

Could you please help review the code?

Here are some **sample codes**.

For the API: **RequestSpotInstances**,

``` go
package main
import (
    "fmt"
    "github.com/mitchellh/goamz/aws"
    "github.com/mitchellh/goamz/ec2"
)

func main() {
    auth, err := aws.EnvAuth()
    if err != nil {
        fmt.Print(err)
        return
    }
    e := ec2.New(auth, aws.USEast)
    options := ec2.RequestSpotInstances{
        SpotPrice:    "0.01",
        ImageId:      "ami-ccf405a5", // Ubuntu Maverick, i386, EBS store
        InstanceType: "m1.small",
    }
    resp, err := e.RequestSpotInstances(&options)
    if err != nil {
        fmt.Print(err)
        return
    }
    for _, spot_request := range resp.SpotRequestResult {
        fmt.Println("New Spot Request Id:", spot_request.SpotRequestId)
    }
    println("Make sure you terminate instances to stop the cash flow.")
}
```

For  the API: **DescribeSpotInstanceRequests**,

``` go
package main
import (
    "fmt"
    "time"
    "github.com/mitchellh/goamz/aws"
    "github.com/mitchellh/goamz/ec2"
)

func main() {
    auth, err := aws.EnvAuth()
    if err != nil {
        fmt.Print(err)
        return
    }
    e := ec2.New(auth, aws.USEast)
    f := ec2.NewFilter()
    spotId := []string{"sir-7448fe49"}
    resp, err := e.DescribeSpotRequests(spotId, f)
    if err != nil {
         fmt.Print(err)
         return
    }
    spotRequest := resp.SpotRequestResult[0]
    fmt.Println("Spot Request Id", spotId, "with current state:", spotRequest.State)
    fmt.Println("Spot Request Id", spotId, "with current instance Id:", spotRequest.InstanceId)
}

```
