### PR TITLE
add the API "CancelSpotRequests" with code cleanup via "go fmt"

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -418,89 +418,89 @@ func clientToken() (string, error) {
 //
 // See http://goo.gl/GRZgCD for more details.
 type RequestSpotInstances struct {
-    SpotPrice                string
-    InstanceCount            int
-    Type                     string
-    ImageId                  string
-    KeyName                  string
-    InstanceType             string
-    SecurityGroups           []SecurityGroup
-    IamInstanceProfile       string
-    KernelId                 string
-    RamdiskId                string
-    UserData                 []byte
-    AvailZone                string
-    PlacementGroupName       string
-    Monitoring               bool
-    SubnetId                 string
-    AssociatePublicIpAddress bool
-    PrivateIPAddress         string
-    BlockDevices             []BlockDeviceMapping
+	SpotPrice                string
+	InstanceCount            int
+	Type                     string
+	ImageId                  string
+	KeyName                  string
+	InstanceType             string
+	SecurityGroups           []SecurityGroup
+	IamInstanceProfile       string
+	KernelId                 string
+	RamdiskId                string
+	UserData                 []byte
+	AvailZone                string
+	PlacementGroupName       string
+	Monitoring               bool
+	SubnetId                 string
+	AssociatePublicIpAddress bool
+	PrivateIPAddress         string
+	BlockDevices             []BlockDeviceMapping
 }
 
 type SpotInstanceSpec struct {
-    ImageId                  string
-    KeyName                  string
-    InstanceType             string
-    SecurityGroups           []SecurityGroup
-    IamInstanceProfile       string
-    KernelId                 string
-    RamdiskId                string
-    UserData                 []byte
-    AvailZone                string
-    PlacementGroupName       string
-    Monitoring               bool
-    SubnetId                 string
-    AssociatePublicIpAddress bool
-    PrivateIPAddress         string
-    BlockDevices             []BlockDeviceMapping
+	ImageId                  string
+	KeyName                  string
+	InstanceType             string
+	SecurityGroups           []SecurityGroup
+	IamInstanceProfile       string
+	KernelId                 string
+	RamdiskId                string
+	UserData                 []byte
+	AvailZone                string
+	PlacementGroupName       string
+	Monitoring               bool
+	SubnetId                 string
+	AssociatePublicIpAddress bool
+	PrivateIPAddress         string
+	BlockDevices             []BlockDeviceMapping
 }
 
 type SpotLaunchSpec struct {
-    ImageId                  string                 `xml:"imageId"`
-    KeyName                  string                 `xml:"keyName"`
-    InstanceType             string                 `xml:"instanceType"`
-    SecurityGroups           []SecurityGroup        `xml:"groupSet>item"`
-    IamInstanceProfile       string                 `xml:"iamInstanceProfile"`
-    KernelId                 string                 `xml:"kernelId"`
-    RamdiskId                string                 `xml:"ramdiskId"`
-    PlacementGroupName       string                 `xml:"placement>groupName"`
-    Monitoring               bool                   `xml:"monitoring>enabled"`
-    SubnetId                 string                 `xml:"subnetId"`
-    BlockDevices             []BlockDeviceMapping   `xml:"blockDeviceMapping>item"`
+	ImageId            string               `xml:"imageId"`
+	KeyName            string               `xml:"keyName"`
+	InstanceType       string               `xml:"instanceType"`
+	SecurityGroups     []SecurityGroup      `xml:"groupSet>item"`
+	IamInstanceProfile string               `xml:"iamInstanceProfile"`
+	KernelId           string               `xml:"kernelId"`
+	RamdiskId          string               `xml:"ramdiskId"`
+	PlacementGroupName string               `xml:"placement>groupName"`
+	Monitoring         bool                 `xml:"monitoring>enabled"`
+	SubnetId           string               `xml:"subnetId"`
+	BlockDevices       []BlockDeviceMapping `xml:"blockDeviceMapping>item"`
 }
 
 type SpotRequestResult struct {
-    SpotRequestId      string           `xml:"spotInstanceRequestId"`
-    SpotPrice          string           `xml:"spotPrice"`
-    Type               string           `xml:"type"`
-    AvailZone          string           `xml:"launchedAvailabilityZone"`
-    InstanceId         string           `xml:"instanceId"`
-    State              string           `xml:"state"`
-    SpotLaunchSpec     SpotLaunchSpec   `xml:"launchSpecification"`
-    CreateTime         string           `xml:"createTime"`
-    Tags               []Tag            `xml:"tagSet>item"`
+	SpotRequestId  string         `xml:"spotInstanceRequestId"`
+	SpotPrice      string         `xml:"spotPrice"`
+	Type           string         `xml:"type"`
+	AvailZone      string         `xml:"launchedAvailabilityZone"`
+	InstanceId     string         `xml:"instanceId"`
+	State          string         `xml:"state"`
+	SpotLaunchSpec SpotLaunchSpec `xml:"launchSpecification"`
+	CreateTime     string         `xml:"createTime"`
+	Tags           []Tag          `xml:"tagSet>item"`
 }
 
 // Response to a RequestSpotInstances request.
 //
 // See http://goo.gl/GRZgCD for more details.
 type RequestSpotInstancesResp struct {
-	RequestId                   string                      `xml:"requestId"`
-	SpotRequestResults          []SpotRequestResult         `xml:"spotInstanceRequestSet>item"`
+	RequestId          string              `xml:"requestId"`
+	SpotRequestResults []SpotRequestResult `xml:"spotInstanceRequestSet>item"`
 }
 
 // RequestSpotInstances requests a new spot instances in EC2.
 func (ec2 *EC2) RequestSpotInstances(options *RequestSpotInstances) (resp *RequestSpotInstancesResp, err error) {
 	params := makeParams("RequestSpotInstances")
-    prefix := "LaunchSpecification" + "."
+	prefix := "LaunchSpecification" + "."
 
-    params["SpotPrice"] = options.SpotPrice
+	params["SpotPrice"] = options.SpotPrice
 	params[prefix+"ImageId"] = options.ImageId
 	params[prefix+"InstanceType"] = options.InstanceType
 
 	if options.InstanceCount != 0 {
-	    params["InstanceCount"] = strconv.Itoa(options.InstanceCount)
+		params["InstanceCount"] = strconv.Itoa(options.InstanceCount)
 	}
 	if options.KeyName != "" {
 		params[prefix+"KeyName"] = options.KeyName
@@ -581,8 +581,8 @@ func (ec2 *EC2) RequestSpotInstances(options *RequestSpotInstances) (resp *Reque
 //
 // See http://goo.gl/KsKJJk for more details.
 type SpotRequestsResp struct {
-	RequestId                   string                      `xml:"requestId"`
-	SpotRequestResults          []SpotRequestResult         `xml:"spotInstanceRequestSet>item"`
+	RequestId          string              `xml:"requestId"`
+	SpotRequestResults []SpotRequestResult `xml:"spotInstanceRequestSet>item"`
 }
 
 // DescribeSpotInstanceRequests returns details about spot requests in EC2.  Both parameters
@@ -595,6 +595,32 @@ func (ec2 *EC2) DescribeSpotRequests(spotrequestIds []string, filter *Filter) (r
 	addParamsList(params, "SpotInstanceRequestId", spotrequestIds)
 	filter.addParams(params)
 	resp = &SpotRequestsResp{}
+	err = ec2.query(params, resp)
+	if err != nil {
+		return nil, err
+	}
+	return
+}
+
+// Response to a CancelSpotInstanceRequests request.
+//
+// See http://goo.gl/3BKHj for more details.
+type CancelSpotRequestResult struct {
+	SpotRequestId string `xml:"spotInstanceRequestId"`
+	State         string `xml:"state"`
+}
+type CancelSpotRequestsResp struct {
+	RequestId                string                    `xml:"requestId"`
+	CancelSpotRequestResults []CancelSpotRequestResult `xml:"spotInstanceRequestSet>item"`
+}
+
+// CancelSpotRequests requests the cancellation of spot requests when the given ids.
+//
+// See http://goo.gl/3BKHj for more details.
+func (ec2 *EC2) CancelSpotRequests(spotrequestIds []string) (resp *CancelSpotRequestsResp, err error) {
+	params := makeParams("CancelSpotInstanceRequests")
+	addParamsList(params, "SpotInstanceRequestId", spotrequestIds)
+	resp = &CancelSpotRequestsResp{}
 	err = ec2.query(params, resp)
 	if err != nil {
 		return nil, err

--- a/ec2/ec2_test.go
+++ b/ec2/ec2_test.go
@@ -63,7 +63,7 @@ func (s *S) TestRequestSpotInstancesErrorDump(c *C) {
 	testServer.Response(400, nil, ErrorDump)
 
 	options := ec2.RequestSpotInstances{
-	    SpotPrice:    "0.01",
+		SpotPrice:    "0.01",
 		ImageId:      "ami-a6f504cf", // Ubuntu Maverick, i386, instance store
 		InstanceType: "t1.micro",     // Doesn't work with micro, results in 400.
 	}
@@ -216,19 +216,19 @@ func (s *S) TestRequestSpotInstancesExample(c *C) {
 	testServer.Response(200, nil, RequestSpotInstancesExample)
 
 	options := ec2.RequestSpotInstances{
-	    SpotPrice:             "0.5",
-		KeyName:               "my-keys",
-		ImageId:               "image-id",
-		InstanceType:          "inst-type",
-		SecurityGroups:        []ec2.SecurityGroup{{Name: "g1"}, {Id: "g2"}, {Name: "g3"}, {Id: "g4"}},
-		UserData:              []byte("1234"),
-		KernelId:              "kernel-id",
-		RamdiskId:             "ramdisk-id",
-		AvailZone:             "zone",
-		PlacementGroupName:    "group",
-		Monitoring:            true,
-		SubnetId:              "subnet-id",
-		PrivateIPAddress:      "10.0.0.25",
+		SpotPrice:          "0.5",
+		KeyName:            "my-keys",
+		ImageId:            "image-id",
+		InstanceType:       "inst-type",
+		SecurityGroups:     []ec2.SecurityGroup{{Name: "g1"}, {Id: "g2"}, {Name: "g3"}, {Id: "g4"}},
+		UserData:           []byte("1234"),
+		KernelId:           "kernel-id",
+		RamdiskId:          "ramdisk-id",
+		AvailZone:          "zone",
+		PlacementGroupName: "group",
+		Monitoring:         true,
+		SubnetId:           "subnet-id",
+		PrivateIPAddress:   "10.0.0.25",
 		BlockDevices: []ec2.BlockDeviceMapping{
 			{DeviceName: "/dev/sdb", VirtualName: "ephemeral0"},
 			{DeviceName: "/dev/sdc", SnapshotId: "snap-a08912c9", DeleteOnTermination: true},
@@ -267,6 +267,21 @@ func (s *S) TestRequestSpotInstancesExample(c *C) {
 	c.Assert(resp.SpotRequestResults[0].SpotLaunchSpec.ImageId, Equals, "ami-1a2b3c4d")
 }
 
+func (s *S) TestCancelSpotRequestsExample(c *C) {
+	testServer.Response(200, nil, CancelSpotRequestsExample)
+
+	resp, err := s.ec2.CancelSpotRequests([]string{"s-1", "s-2"})
+
+	req := testServer.WaitRequest()
+	c.Assert(req.Form["Action"], DeepEquals, []string{"CancelSpotInstanceRequests"})
+	c.Assert(req.Form["SpotInstanceRequestId.1"], DeepEquals, []string{"s-1"})
+	c.Assert(req.Form["SpotInstanceRequestId.2"], DeepEquals, []string{"s-2"})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "59dbff89-35bd-4eac-99ed-be587EXAMPLE")
+	c.Assert(resp.CancelSpotRequestResults[0].SpotRequestId, Equals, "sir-1a2b3c4d")
+	c.Assert(resp.CancelSpotRequestResults[0].State, Equals, "cancelled")
+}
 
 func (s *S) TestTerminateInstancesExample(c *C) {
 	testServer.Response(200, nil, TerminateInstancesExample)
@@ -298,7 +313,6 @@ func (s *S) TestTerminateInstancesExample(c *C) {
 	c.Assert(resp.StateChanges[0].PreviousState.Name, Equals, "running")
 }
 
-
 func (s *S) TestDescribeSpotRequestsExample(c *C) {
 	testServer.Response(200, nil, DescribeSpotRequestsExample)
 
@@ -306,8 +320,8 @@ func (s *S) TestDescribeSpotRequestsExample(c *C) {
 	filter.Add("key1", "value1")
 	filter.Add("key2", "value2", "value3")
 
-	resp, err := s.ec2.DescribeSpotRequests([]string{"s-1", "s-2"}, filter) 
- 
+	resp, err := s.ec2.DescribeSpotRequests([]string{"s-1", "s-2"}, filter)
+
 	req := testServer.WaitRequest()
 	c.Assert(req.Form["Action"], DeepEquals, []string{"DescribeSpotInstanceRequests"})
 	c.Assert(req.Form["SpotInstanceRequestId.1"], DeepEquals, []string{"s-1"})

--- a/ec2/responses_test.go
+++ b/ec2/responses_test.go
@@ -174,6 +174,19 @@ var DescribeSpotRequestsExample = `
 </DescribeSpotInstanceRequestsResponse>
 `
 
+// http://goo.gl/DcfFgJ
+var CancelSpotRequestsExample = `
+<CancelSpotInstanceRequestsResponse xmlns="http://ec2.amazonaws.com/doc/2014-02-01/">
+  <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
+  <spotInstanceRequestSet>
+    <item>
+      <spotInstanceRequestId>sir-1a2b3c4d</spotInstanceRequestId>
+      <state>cancelled</state>
+    </item>
+  </spotInstanceRequestSet>
+</CancelSpotInstanceRequestsResponse>
+`
+
 // http://goo.gl/3BKHj
 var TerminateInstancesExample = `
 <TerminateInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2011-12-15/">


### PR DESCRIPTION
@mitchellh

I have added the API "CancelSpotRequests" also with code cleanup via "go fmt" this time.

``` go
package main

import (
        "fmt"
        "github.com/mitchellh/goamz/aws"
        "github.com/mitchellh/goamz/ec2"
)

func main() {
        auth, err := aws.EnvAuth()
        if err != nil {
                fmt.Print(err)
                return
        }
        e := ec2.New(auth, aws.USEast)
        options := ec2.RequestSpotInstances{
                SpotPrice:    "0.001",
                ImageId:      "ami-ccf405a5", // Ubuntu Maverick, i386, EBS store
                InstanceType: "m1.small",
        }
        resp, err := e.RequestSpotInstances(&options)
        if err != nil {
                fmt.Print(err)
                return
        }
        spotRequest := resp.SpotRequestResults[0]
        spotId := []string{spotRequest.SpotRequestId}
        fmt.Println("New created Spot Request Id:", spotId)
        resp2, err := e.CancelSpotRequests(spotId)
        if err != nil {
                fmt.Print(err)
                return
        }
        spotResult := resp2.CancelSpotRequestResults[0]
        fmt.Println("Spot Request Id [", spotResult.SpotRequestId, "] State:", spotResult.State)
}
```
