### PR TITLE
Amazon expects and empty string for NoDevice if it is set

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -225,7 +225,7 @@ func addBlockDeviceParams(prename string, params map[string]string, blockdevices
 			params[prefix+"Ebs.Encrypted"] = "true"
 		}
 		if k.NoDevice {
-			params[prefix+"NoDevice"] = "true"
+			params[prefix+"NoDevice"] = ""
 		}
 	}
 }


### PR DESCRIPTION
Was unable to successfully create ami's with packer that had no ephemeral storage defined.  After reviewing the docs at http://docs.aws.amazon.com/cli/latest/reference/ec2/create-image.html and looking at how boto handles block devices, determined that EC2 expects an empty string if NoDevice is set.

Have successfully built ami's without ephemeral devices using this fix.
