### PR TITLE
use Opaque instead of Path

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -586,7 +586,7 @@ func (req *request) url() (*url.URL, error) {
 		return nil, fmt.Errorf("bad S3 endpoint URL %q: %v", req.baseurl, err)
 	}
 	u.RawQuery = req.params.Encode()
-	u.Path = req.path
+	u.Opaque = req.path
 	return u, nil
 }
 


### PR DESCRIPTION
I've been trying to download files with exclamation points in them (really weird, I know) and have been having some issues.

For example if I attempt to download a file at https://s3-us-west-2.amazonaws.com/opaque-example/hello!world.txt

```bash
$ curl https://s3-us-west-2.amazonaws.com/opaque-example/hello\!world.txt
hello, world

How are you?
```

However when I use the s3 library I get:
```go
package main

import (
	"fmt"
	"github.com/mitchellh/goamz/aws"
	"github.com/mitchellh/goamz/s3"
	"os"
)

func main() {
	auth, _ := aws.GetAuth("", "")
	bucket := s3.New(auth, aws.Regions["us-west-2"]).Bucket("opaque-example")
	data, err := bucket.Get("hello!world.txt")
	if err == nil {
		os.Stdout.Write(data)
	} else {
		fmt.Println(err)
	}
}
```
```bash
$ go run badrequest.go
The request signature we calculated does not match the signature you provided. Check your key and signing method.
```

After a bit of digging, it seems like the client is getting confused about the URL path. It's escaping the `!` into `%21` but there are still problems. To attempt to remedy this I've switched the generated URL for the `s3.run()` request from using the `Path` field to the `Opaque` field. You can read about that feature [here](http://golang.org/pkg/net/url/#URL).

Following the change, the above code outputs the following:
```bash
$ go run badrequest.go
hello, world

How are you?
```

Don't know quite how to run the tests but I'd like to get some feedback on this change. I couldn't get exclamation points to work otherwise because it's coded pretty deep into the library.