### PR TITLE
Implementation of Copy operation for S3 Buckets.

### DIFF
--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -272,6 +272,24 @@ func (s *S) TestPutReaderHeader(c *C) {
 	c.Assert(req.Header["X-Amz-Acl"], DeepEquals, []string{"private"})
 }
 
+func (s *S) TestCopy(c *C) {
+	testServer.Response(200, nil, "")
+
+	b := s.s3.Bucket("bucket")
+	err := b.Copy(
+		"old/file",
+		"new/file",
+		s3.Private,
+	)
+	c.Assert(err, IsNil)
+
+	req := testServer.WaitRequest()
+	c.Assert(req.Method, Equals, "PUT")
+	c.Assert(req.URL.Path, Equals, "/bucket/new/file")
+	c.Assert(req.Header["X-Amz-Copy-Source"], DeepEquals, []string{"/bucket/old/file"})
+	c.Assert(req.Header["X-Amz-Acl"], DeepEquals, []string{"private"})
+}
+
 // DelObject docs: http://goo.gl/APeTt
 
 func (s *S) TestDelObject(c *C) {

--- a/s3/s3i_test.go
+++ b/s3/s3i_test.go
@@ -221,6 +221,31 @@ func (s *ClientTests) TestBasicFunctionality(c *C) {
 	c.Assert(err, IsNil)
 }
 
+func (s *ClientTests) TestCopy(c *C) {
+	b := testBucket(s.s3)
+	err := b.PutBucket(s3.PublicRead)
+
+	err = b.Put("name", []byte("yo!"), "text/plain", s3.PublicRead)
+	c.Assert(err, IsNil)
+	defer b.Del("name")
+
+	err = b.Copy("name", "name2", s3.PublicRead)
+	c.Assert(err, IsNil)
+	defer b.Del("name2")
+
+	data, err := b.Get("name2")
+	c.Assert(err, IsNil)
+	c.Assert(string(data), Equals, "yo!")
+
+	err = b.Del("name")
+	c.Assert(err, IsNil)
+	err = b.Del("name2")
+	c.Assert(err, IsNil)
+
+	err = b.DelBucket()
+	c.Assert(err, IsNil)
+}
+
 func (s *ClientTests) TestGetNotFound(c *C) {
 	b := s.s3.Bucket("goamz-" + s.s3.Auth.AccessKey)
 	data, err := b.Get("non-existent")


### PR DESCRIPTION
Copy documentation: http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectCOPY.html
