### PR TITLE
Plus sign in S3 URIs

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -308,7 +308,7 @@ func (b *Bucket) Copy(oldPath, newPath string, perm ACL) error {
 		bucket: b.Name,
 		path:   newPath,
 		headers: map[string][]string{
-			"x-amz-copy-source": {(&url.URL{Path: "/" + b.Name + oldPath}).String()},
+			"x-amz-copy-source": {strings.Replace((&url.URL{Path: "/" + b.Name + oldPath}).RequestURI(), "+", "%2B", -1)},
 			"x-amz-acl":         {string(perm)},
 		},
 	}
@@ -621,8 +621,11 @@ func (req *request) url() (*url.URL, error) {
 	if err != nil {
 		return nil, fmt.Errorf("bad S3 endpoint URL %q: %v", req.baseurl, err)
 	}
+
+	// Amazon treats '+' in URI as space, so it should be escaped
+	u.Opaque = strings.Replace((&url.URL{Path: req.path}).RequestURI(), "+", "%2B", -1)
 	u.RawQuery = req.params.Encode()
-	u.Path = req.path
+
 	return u, nil
 }
 

--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -290,6 +290,24 @@ func (s *S) TestCopy(c *C) {
 	c.Assert(req.Header["X-Amz-Acl"], DeepEquals, []string{"private"})
 }
 
+func (s *S) TestPlusInURL(c *C) {
+	testServer.Response(200, nil, "")
+
+	b := s.s3.Bucket("bucket")
+	err := b.Copy(
+		"dir/old+f?le",
+		"dir/new+f?le",
+		s3.Private,
+	)
+	c.Assert(err, IsNil)
+
+	req := testServer.WaitRequest()
+	c.Assert(req.Method, Equals, "PUT")
+	c.Assert(req.RequestURI, Equals, "/bucket/dir/new%2Bf%3Fle")
+	c.Assert(req.Header["X-Amz-Copy-Source"], DeepEquals, []string{"/bucket/dir/old%2Bf%3Fle"})
+	c.Assert(req.Header["X-Amz-Acl"], DeepEquals, []string{"private"})
+}
+
 // DelObject docs: http://goo.gl/APeTt
 
 func (s *S) TestDelObject(c *C) {


### PR DESCRIPTION
Fix issue with '+' in item names: Amazon treats it as space, but net/http doesn't escape it.

Details: https://groups.google.com/forum/#!topic/golang-nuts/CbL27WPZavY

Escape manually '+' as '%2B' in URIs sent to S3 API.
