### PR TITLE
Fix URI encoding in requests and signing, use Amazon method of URI encoding.

### DIFF
--- a/s3/s3i_test.go
+++ b/s3/s3i_test.go
@@ -225,21 +225,21 @@ func (s *ClientTests) TestCopy(c *C) {
 	b := testBucket(s.s3)
 	err := b.PutBucket(s3.PublicRead)
 
-	err = b.Put("name", []byte("yo!"), "text/plain", s3.PublicRead)
+	err = b.Put("name+1", []byte("yo!"), "text/plain", s3.PublicRead)
 	c.Assert(err, IsNil)
-	defer b.Del("name")
+	defer b.Del("name+1")
 
-	err = b.Copy("name", "name2", s3.PublicRead)
+	err = b.Copy("name+1", "name+2", s3.PublicRead)
 	c.Assert(err, IsNil)
-	defer b.Del("name2")
+	defer b.Del("name+2")
 
-	data, err := b.Get("name2")
+	data, err := b.Get("name+2")
 	c.Assert(err, IsNil)
 	c.Assert(string(data), Equals, "yo!")
 
-	err = b.Del("name")
+	err = b.Del("name+1")
 	c.Assert(err, IsNil)
-	err = b.Del("name2")
+	err = b.Del("name+2")
 	c.Assert(err, IsNil)
 
 	err = b.DelBucket()


### PR DESCRIPTION
Signed URIs should be encoded exactly the same as URIs in HTTP request.
1. net/url methods for encoding do not match Amazon's methods of encoding, so we
   need our own method to escape URIs.
2. url.URL has problems with handling of .Opaque (alreay encoded) paths:
   - when calling .String(), it assumes that .Opaque contains "//host" part
   - when calling .RequestURI(), it assumes that there's no "//host" part, only path.

The change with request.url(full bool) looks ugly, but I see no better way to handle that.

Sorry for making so many pull requests, but this version seems to handle all corner cases.
