### PR TITLE
Allow eucalyptus region to be configured via ENV

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -190,6 +190,23 @@ var SAEast = Region{
 	"https://route53.amazonaws.com",
 }
 
+var Eucalyptus = Region{
+	"eucalyptus",
+	os.Getenv("EC2_URL"),
+	os.Getenv("S3_URL"),
+	"",
+	true,
+	true,
+	"",
+	"",
+	"",
+	os.Getenv("EUARE_URL"),
+	os.Getenv("AWS_ELB_URL"),
+	os.Getenv("AWS_AUTOSCALING_URL"),
+	"",
+	"",
+}
+
 var Regions = map[string]Region{
 	APNortheast.Name:  APNortheast,
 	APSoutheast.Name:  APSoutheast,
@@ -200,6 +217,7 @@ var Regions = map[string]Region{
 	USWest2.Name:      USWest2,
 	SAEast.Name:       SAEast,
 	USGovWest.Name:    USGovWest,
+        Eucalyptus.Name:   Eucalyptus,
 }
 
 type Auth struct {


### PR DESCRIPTION
I tried to keep this as simple as possible. 

Eucalyptus users will need to:
- Set "eucalyptus" as the region
- Source their eucarc file or manually export the following environment variables
  - EC2_URL
  - S3_URL
  - EUARE_URL
  - AWS_ELB_URL
  - AWS_AUTOSCALING_URL
