### PR TITLE
Add spot instance status codes to response structs

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -478,6 +478,12 @@ type SpotLaunchSpec struct {
 	BlockDevices       []BlockDeviceMapping `xml:"blockDeviceMapping>item"`
 }
 
+type SpotStatus struct {
+	Code       string `xml:"code"`
+	UpdateTime string `xml:"updateTime"`
+	Message    string `xml:"message"`
+}
+
 type SpotRequestResult struct {
 	SpotRequestId  string         `xml:"spotInstanceRequestId"`
 	SpotPrice      string         `xml:"spotPrice"`
@@ -485,6 +491,7 @@ type SpotRequestResult struct {
 	AvailZone      string         `xml:"launchedAvailabilityZone"`
 	InstanceId     string         `xml:"instanceId"`
 	State          string         `xml:"state"`
+	Status         SpotStatus     `xml:"status"`
 	SpotLaunchSpec SpotLaunchSpec `xml:"launchSpecification"`
 	CreateTime     string         `xml:"createTime"`
 	Tags           []Tag          `xml:"tagSet>item"`

--- a/ec2/ec2_test.go
+++ b/ec2/ec2_test.go
@@ -266,6 +266,9 @@ func (s *S) TestRequestSpotInstancesExample(c *C) {
 	c.Assert(resp.SpotRequestResults[0].SpotPrice, Equals, "0.5")
 	c.Assert(resp.SpotRequestResults[0].State, Equals, "open")
 	c.Assert(resp.SpotRequestResults[0].SpotLaunchSpec.ImageId, Equals, "ami-1a2b3c4d")
+	c.Assert(resp.SpotRequestResults[0].Status.Code, Equals, "pending-evaluation")
+	c.Assert(resp.SpotRequestResults[0].Status.UpdateTime, Equals, "2008-05-07T12:51:50.000Z")
+	c.Assert(resp.SpotRequestResults[0].Status.Message, Equals, "Your Spot request has been submitted for review, and is pending evaluation.")
 }
 
 func (s *S) TestCancelSpotRequestsExample(c *C) {
@@ -334,6 +337,9 @@ func (s *S) TestDescribeSpotRequestsExample(c *C) {
 	c.Assert(resp.SpotRequestResults[0].State, Equals, "active")
 	c.Assert(resp.SpotRequestResults[0].SpotPrice, Equals, "0.5")
 	c.Assert(resp.SpotRequestResults[0].SpotLaunchSpec.ImageId, Equals, "ami-1a2b3c4d")
+	c.Assert(resp.SpotRequestResults[0].Status.Code, Equals, "fulfilled")
+	c.Assert(resp.SpotRequestResults[0].Status.UpdateTime, Equals, "2008-05-07T12:51:50.000Z")
+	c.Assert(resp.SpotRequestResults[0].Status.Message, Equals, "Your Spot request is fulfilled.")
 }
 
 func (s *S) TestDescribeInstancesExample1(c *C) {

--- a/ec2/responses_test.go
+++ b/ec2/responses_test.go
@@ -108,7 +108,7 @@ var RequestSpotInstancesExample = `
       <state>open</state>
       <status>
         <code>pending-evaluation</code>
-        <updateTime>YYYY-MM-DDTHH:MM:SS.000Z</updateTime>
+        <updateTime>2008-05-07T12:51:50.000Z</updateTime>
         <message>Your Spot request has been submitted for review, and is pending evaluation.</message>
       </status>
       <availabilityZoneGroup>MyAzGroup</availabilityZoneGroup>
@@ -147,7 +147,7 @@ var DescribeSpotRequestsExample = `
       <state>active</state>
       <status>
         <code>fulfilled</code>
-        <updateTime>YYYY-MM-DDTHH:MM:SS.000Z</updateTime>
+        <updateTime>2008-05-07T12:51:50.000Z</updateTime>
         <message>Your Spot request is fulfilled.</message>
       </status>
       <launchSpecification>


### PR DESCRIPTION
This adds fields to the SpotRequestResult struct to expose the status code, message, and update time of the spot request.
