### PR TITLE
Add SSLCertificateId to elb listeners

### DIFF
--- a/elb/elb.go
+++ b/elb/elb.go
@@ -93,6 +93,7 @@ func makeParams(action string) map[string]string {
 type Listener struct {
 	InstancePort     int64  `xml:"member>Listener>InstancePort"`
 	InstanceProtocol string `xml:"member>Listener>InstanceProtocol"`
+	SSLCertificateId string `xml:"member>Listener>SSLCertificateId"`
 	LoadBalancerPort int64  `xml:"member>Listener>LoadBalancerPort"`
 	Protocol         string `xml:"member>Listener>Protocol"`
 }
@@ -155,6 +156,7 @@ func (elb *ELB) CreateLoadBalancer(options *CreateLoadBalancer) (resp *CreateLoa
 		params["Listeners.member."+strconv.Itoa(i+1)+".InstancePort"] = strconv.FormatInt(v.InstancePort, 10)
 		params["Listeners.member."+strconv.Itoa(i+1)+".Protocol"] = v.Protocol
 		params["Listeners.member."+strconv.Itoa(i+1)+".InstanceProtocol"] = v.InstanceProtocol
+		params["Listeners.member."+strconv.Itoa(i+1)+".SSLCertificateId"] = v.SSLCertificateId
 	}
 
 	if options.Internal {

--- a/elb/elb_test.go
+++ b/elb/elb_test.go
@@ -38,6 +38,7 @@ func (s *S) TestCreateLoadBalancer(c *C) {
 		Listeners: []elb.Listener{elb.Listener{
 			InstancePort:     80,
 			InstanceProtocol: "http",
+			SSLCertificateId: "needToAddASSLCertToYourAWSAccount",
 			LoadBalancerPort: 80,
 			Protocol:         "http",
 		},

--- a/elb/responses_test.go
+++ b/elb/responses_test.go
@@ -51,6 +51,7 @@ var DescribeLoadBalancersExample = `
                 <Protocol>HTTP</Protocol>
                 <LoadBalancerPort>80</LoadBalancerPort>
                 <InstanceProtocol>HTTP</InstanceProtocol>
+                <SSLCertificateId>needToAddASSLCertToYourAWSAccount</SSLCertificateId>
                 <InstancePort>80</InstancePort>
               </Listener>
             </member>


### PR DESCRIPTION
This is a step towards implementing `ELB > SSL Configuration` from the Terraform [AWS provider meta coverage issue](https://github.com/hashicorp/terraform/issues/28).

Note: `needToAddASSLCertToYourAWSAccount` used as a dummy name for an ssl cert.
