### PR TITLE
Read token from AWS_SECURITY_TOKEN env variable

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -313,7 +313,7 @@ func EnvAuth() (auth Auth, err error) {
 		auth.SecretKey = os.Getenv("AWS_SECRET_KEY")
 	}
 
-  auth.Token = os.Getenv("AWS_SECURITY_TOKEN")
+	auth.Token = os.Getenv("AWS_SECURITY_TOKEN")
 
 	if auth.AccessKey == "" {
 		err = errors.New("AWS_ACCESS_KEY_ID or AWS_ACCESS_KEY not found in environment")

--- a/aws/aws_test.go
+++ b/aws/aws_test.go
@@ -53,13 +53,13 @@ func (s *S) TestEnvAuth(c *C) {
 }
 
 func (s *S) TestEnvAuthWithToken(c *C) {
-  os.Clearenv()
-  os.Setenv("AWS_SECRET_ACCESS_KEY", "secret")
-  os.Setenv("AWS_ACCESS_KEY_ID", "access")
-  os.Setenv("AWS_SECURITY_TOKEN", "token")
-  auth, err := aws.EnvAuth()
-  c.Assert(err, IsNil)
-  c.Assert(auth, Equals, aws.Auth{SecretKey: "secret", AccessKey: "access", Token: "token"})
+	os.Clearenv()
+	os.Setenv("AWS_SECRET_ACCESS_KEY", "secret")
+	os.Setenv("AWS_ACCESS_KEY_ID", "access")
+	os.Setenv("AWS_SECURITY_TOKEN", "token")
+	auth, err := aws.EnvAuth()
+	c.Assert(err, IsNil)
+	c.Assert(auth, Equals, aws.Auth{SecretKey: "secret", AccessKey: "access", Token: "token"})
 }
 
 func (s *S) TestEnvAuthAlt(c *C) {


### PR DESCRIPTION
We have an application that is using temporary security credentials which are not delivered via an EC2 Role.  This PR adds support for setting the Token via the standard AWS_SECURITY_TOKEN env variable.  It does not affect any existing functionality.

More info: http://docs.aws.amazon.com/STS/latest/UsingSTS/using-temp-creds.html#using-temp-creds-sdk-ec2-instances

@mitchellh
