### PR TITLE
Add Shared Credentials support

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"github.com/vaughan0/go-ini"
 )
 
 // Region defines the URLs where AWS services may be accessed.
@@ -279,6 +280,13 @@ func GetAuth(accessKey string, secretKey string) (auth Auth, err error) {
 	}
 
 	// Next try to get auth from the environment
+	auth, err = SharedAuth()
+	if err == nil {
+		// Found auth, return
+		return
+	}
+
+	// Next try to get auth from the environment
 	auth, err = EnvAuth()
 	if err == nil {
 		// Found auth, return
@@ -295,6 +303,47 @@ func GetAuth(accessKey string, secretKey string) (auth Auth, err error) {
 		return
 	}
 	err = errors.New("No valid AWS authentication found")
+	return
+}
+
+// SharedAuth creates an Auth based on shared credentials stored in
+// $HOME/.aws/credentials. The AWS_PROFILE environment variables is used to
+// select the profile.
+func SharedAuth() (auth Auth, err error) {
+	var profileName = os.Getenv("AWS_PROFILE")
+
+	if profileName == "" {
+		profileName = "default"
+	}
+
+	var homeDir = os.Getenv("HOME")
+	if homeDir == "" {
+		err = errors.New("Could not get HOME")
+		return
+	}
+
+	var credentialsFile = homeDir + "/.aws/credentials"
+	file, err := ini.LoadFile(credentialsFile)
+	if err != nil {
+		err = errors.New("Couldn't parse AWS credentials file")
+		return
+	}
+
+	var profile = file[profileName]
+	if profile == nil {
+		err = errors.New("Couldn't find profile in AWS credentials file")
+		return
+	}
+
+	auth.AccessKey = profile["aws_access_key_id"]
+	auth.SecretKey = profile["aws_secret_access_key"]
+
+	if auth.AccessKey == "" {
+		err = errors.New("AWS_ACCESS_KEY_ID not found in environment in credentials file")
+	}
+	if auth.SecretKey == "" {
+		err = errors.New("AWS_SECRET_ACCESS_KEY not found in credentials file")
+	}
 	return
 }
 

--- a/aws/aws_test.go
+++ b/aws/aws_test.go
@@ -3,6 +3,7 @@ package aws_test
 import (
 	"github.com/mitchellh/goamz/aws"
 	. "github.com/motain/gocheck"
+	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -28,6 +29,94 @@ func (s *S) TearDownTest(c *C) {
 		l := strings.SplitN(kv, "=", 2)
 		os.Setenv(l[0], l[1])
 	}
+}
+
+func (s *S) TestSharedAuthNoHome(c *C) {
+	os.Clearenv()
+	os.Setenv("AWS_PROFILE", "foo")
+	_, err := aws.SharedAuth()
+	c.Assert(err, ErrorMatches, "Could not get HOME")
+}
+
+func (s *S) TestSharedAuthNoCredentialsFile(c *C) {
+	os.Clearenv()
+	os.Setenv("AWS_PROFILE", "foo")
+	os.Setenv("HOME", "/tmp")
+	_, err := aws.SharedAuth()
+	c.Assert(err, ErrorMatches, "Couldn't parse AWS credentials file")
+}
+
+func (s *S) TestSharedAuthNoProfileInFile(c *C) {
+	os.Clearenv()
+	os.Setenv("AWS_PROFILE", "foo")
+
+	d, err := ioutil.TempDir("", "")
+	if err != nil { panic(err) }
+	defer os.RemoveAll(d)
+
+	err = os.Mkdir(d + "/.aws", 0755)
+	if err != nil { panic(err) }
+
+	ioutil.WriteFile(d + "/.aws/credentials", []byte("[bar]\n"), 0644)
+	os.Setenv("HOME", d)
+
+	_, err = aws.SharedAuth()
+	c.Assert(err, ErrorMatches, "Couldn't find profile in AWS credentials file")
+}
+
+func (s *S) TestSharedAuthNoKeysInProfile(c *C) {
+	os.Clearenv()
+	os.Setenv("AWS_PROFILE", "bar")
+
+	d, err := ioutil.TempDir("", "")
+	if err != nil { panic(err) }
+	defer os.RemoveAll(d)
+
+	err = os.Mkdir(d + "/.aws", 0755)
+	if err != nil { panic(err) }
+
+	ioutil.WriteFile(d + "/.aws/credentials", []byte("[bar]\nawsaccesskeyid = AK.."), 0644)
+	os.Setenv("HOME", d)
+
+	_, err = aws.SharedAuth()
+	c.Assert(err, ErrorMatches, "AWS_SECRET_ACCESS_KEY not found in credentials file")
+}
+
+func (s *S) TestSharedAuthDefaultCredentials(c *C) {
+	os.Clearenv()
+
+	d, err := ioutil.TempDir("", "")
+	if err != nil { panic(err) }
+	defer os.RemoveAll(d)
+
+	err = os.Mkdir(d + "/.aws", 0755)
+	if err != nil { panic(err) }
+
+	ioutil.WriteFile(d + "/.aws/credentials", []byte("[default]\naws_access_key_id = access\naws_secret_access_key = secret\n"), 0644)
+	os.Setenv("HOME", d)
+
+	auth, err := aws.SharedAuth()
+	c.Assert(err, IsNil)
+	c.Assert(auth, Equals, aws.Auth{SecretKey: "secret", AccessKey: "access"})
+}
+
+func (s *S) TestSharedAuth(c *C) {
+	os.Clearenv()
+	os.Setenv("AWS_PROFILE", "bar")
+
+	d, err := ioutil.TempDir("", "")
+	if err != nil { panic(err) }
+	defer os.RemoveAll(d)
+
+	err = os.Mkdir(d + "/.aws", 0755)
+	if err != nil { panic(err) }
+
+	ioutil.WriteFile(d + "/.aws/credentials", []byte("[bar]\naws_access_key_id = access\naws_secret_access_key = secret\n"), 0644)
+	os.Setenv("HOME", d)
+
+	auth, err := aws.SharedAuth()
+	c.Assert(err, IsNil)
+	c.Assert(auth, Equals, aws.Auth{SecretKey: "secret", AccessKey: "access"})
 }
 
 func (s *S) TestEnvAuthNoSecret(c *C) {


### PR DESCRIPTION
Most AWS SDKs now support the use of shared profiles in
~/.aws/credentials. The AWS_PROFILE environment variable is then used to
pick the profile to be used.
