### PR TITLE
Feature Request: add RDS snapshot describe / restore methods.

### DIFF
--- a/rds/rds.go
+++ b/rds/rds.go
@@ -469,6 +469,91 @@ func (rds *Rds) DeleteDBSecurityGroup(options *DeleteDBSecurityGroup) (resp *Sim
 	return
 }
 
+type RestoreDBInstanceFromDBSnapshot struct {
+	DBInstanceIdentifier    string
+	DBSnapshotIdentifier    string
+	AutoMinorVersionUpgrade bool
+	AvailabilityZone        string
+	DBInstanceClass         string
+	DBName                  string
+	DBSubnetGroupName       string
+	Engine                  string
+	Iops                    int
+	LicenseModel            string
+	MultiAZ                 bool
+	OptionGroupName         string
+	Port                    int
+	PubliclyAccessible      bool
+
+	SetIops bool
+	SetPort bool
+}
+
+func (rds *Rds) RestoreDBInstanceFromDBSnapshot(options *RestoreDBInstanceFromDBSnapshot) (resp *SimpleResp, err error) {
+	params := makeParams("RestoreDBInstanceFromDBSnapshot")
+
+	params["DBInstanceIdentifier"] = options.DBInstanceIdentifier
+	params["DBSnapshotIdentifier"] = options.DBSnapshotIdentifier
+
+	if options.AutoMinorVersionUpgrade {
+		params["AutoMinorVersionUpgrade"] = "true"
+	}
+
+	if options.AvailabilityZone != "" {
+		params["AvailabilityZone"] = options.AvailabilityZone
+	}
+
+	if options.DBInstanceClass != "" {
+		params["DBInstanceClass"] = options.DBInstanceClass
+	}
+
+	if options.DBName != "" {
+		params["DBName"] = options.DBName
+	}
+
+	if options.DBSubnetGroupName != "" {
+		params["DBSubnetGroupName"] = options.DBSubnetGroupName
+	}
+
+	if options.Engine != "" {
+		params["Engine"] = options.Engine
+	}
+
+	if options.SetIops {
+		params["Iops"] = strconv.Itoa(options.Iops)
+	}
+
+	if options.LicenseModel != "" {
+		params["LicenseModel"] = options.LicenseModel
+	}
+
+	if options.MultiAZ {
+		params["MultiAZ"] = "true"
+	}
+
+	if options.OptionGroupName != "" {
+		params["OptionGroupName"] = options.OptionGroupName
+	}
+
+	if options.SetPort {
+		params["Port"] = strconv.Itoa(options.Port)
+	}
+
+	if options.PubliclyAccessible {
+		params["PubliclyAccessible"] = "true"
+	}
+
+	resp = &SimpleResp{}
+
+	err = rds.query(params, resp)
+
+	if err != nil {
+		resp = nil
+	}
+
+	return
+}
+
 // Responses
 
 type SimpleResp struct {

--- a/rds/rds_test.go
+++ b/rds/rds_test.go
@@ -213,3 +213,21 @@ func (s *S) Test_DescribeDBSnapshots(c *C) {
 	c.Assert(resp.DBSnapshots[0].Engine, Equals, "mysql")
 	c.Assert(resp.DBSnapshots[0].SnapshotType, Equals, "manual")
 }
+
+func (s *S) Test_RestoreDBInstanceFromDBSnapshot(c *C) {
+	testServer.Response(200, nil, RestoreDBInstanceFromDBSnapshotExample)
+
+	options := rds.RestoreDBInstanceFromDBSnapshot{
+		DBInstanceIdentifier: "foo",
+		DBSnapshotIdentifier: "bar",
+	}
+
+	resp, err := s.rds.RestoreDBInstanceFromDBSnapshot(&options)
+	req := testServer.WaitRequest()
+
+	c.Assert(req.Form["Action"], DeepEquals, []string{"RestoreDBInstanceFromDBSnapshot"})
+	c.Assert(req.Form["DBInstanceIdentifier"], DeepEquals, []string{"foo"})
+	c.Assert(req.Form["DBSnapshotIdentifier"], DeepEquals, []string{"bar"})
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "863fd73e-be2b-11d3-855b-576787000e19")
+}

--- a/rds/responses_test.go
+++ b/rds/responses_test.go
@@ -390,3 +390,51 @@ var DescribeDBSnapshotsExample = `
   </ResponseMetadata>
 </DescribeDBSnapshotsResponse>
 `
+
+var RestoreDBInstanceFromDBSnapshotExample = `
+<RestoreDBInstanceFromDBSnapshotResponse xmlns="http://rds.amazonaws.com/doc/2013-09-09/">
+  <RestoreDBInstanceFromDBSnapshotResult>
+    <DBInstance>
+      <BackupRetentionPeriod>2</BackupRetentionPeriod>
+      <MultiAZ>false</MultiAZ>
+      <DBInstanceStatus>creating</DBInstanceStatus>
+      <VpcSecurityGroups/>
+      <DBInstanceIdentifier>mysqldb-restored</DBInstanceIdentifier>
+      <PreferredBackupWindow>08:14-08:44</PreferredBackupWindow>
+      <PreferredMaintenanceWindow>fri:04:50-fri:05:20</PreferredMaintenanceWindow>
+      <ReadReplicaDBInstanceIdentifiers/>
+      <Engine>mysql</Engine>
+      <PendingModifiedValues/>
+      <LicenseModel>general-public-license</LicenseModel>
+      <EngineVersion>5.6.13</EngineVersion>
+      <DBParameterGroups>
+        <DBParameterGroup>
+          <ParameterApplyStatus>in-sync</ParameterApplyStatus>
+          <DBParameterGroupName>default.mysql5.6</DBParameterGroupName>
+        </DBParameterGroup>
+      </DBParameterGroups>
+      <OptionGroupMemberships>
+        <OptionGroupMembership>
+          <OptionGroupName>default:mysql-5-6</OptionGroupName>
+          <Status>pending-apply</Status>
+        </OptionGroupMembership>
+      </OptionGroupMemberships>
+      <PubliclyAccessible>true</PubliclyAccessible>
+      <DBSecurityGroups>
+        <DBSecurityGroup>
+          <Status>active</Status>
+          <DBSecurityGroupName>default</DBSecurityGroupName>
+        </DBSecurityGroup>
+      </DBSecurityGroups>
+      <DBName>mysqldb</DBName>
+      <AutoMinorVersionUpgrade>true</AutoMinorVersionUpgrade>
+      <AllocatedStorage>100</AllocatedStorage>
+      <MasterUsername>myawsuser</MasterUsername>
+      <DBInstanceClass>db.m1.medium</DBInstanceClass>
+    </DBInstance>
+  </RestoreDBInstanceFromDBSnapshotResult>
+  <ResponseMetadata>
+    <RequestId>863fd73e-be2b-11d3-855b-576787000e19</RequestId>
+  </ResponseMetadata>
+</RestoreDBInstanceFromDBSnapshotResponse>
+`


### PR DESCRIPTION
I want more RDS API methods, DescribeDBSnapshots and RestoreDBInstanceFromDBSnapshot methods.
http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DBSnapshot.html
http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DescribeDBInstances.html
http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_RestoreDBInstanceFromDBSnapshot.html
so I created this patch.

Please review and merge it. :)
