### PR TITLE
Add ListHostedZones API endpoint

### DIFF
--- a/route53/responses_test.go
+++ b/route53/responses_test.go
@@ -94,3 +94,29 @@ var ListResourceRecordSetsExample = `<?xml version="1.0" encoding="UTF-8"?>
    <NextRecordName>testdoc2.example.com</NextRecordName>
    <NextRecordType>NS</NextRecordType>
 </ListResourceRecordSetsResponse>`
+
+var ListHostedZonesExample = `<?xml version="1.0" encoding="utf-8"?>
+<ListHostedZonesResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+    <HostedZones>
+        <HostedZone>
+            <Id>/hostedzone/Z2K123214213123</Id>
+            <Name>example.com.</Name>
+            <CallerReference>D2224C5B-684A-DB4A-BB9A-E09E3BAFEA7A</CallerReference>
+            <Config>
+                <Comment>Test comment</Comment>
+            </Config>
+            <ResourceRecordSetCount>10</ResourceRecordSetCount>
+        </HostedZone>
+        <HostedZone>
+            <Id>/hostedzone/ZLT12321321124</Id>
+            <Name>sub.example.com.</Name>
+            <CallerReference>A970F076-FCB1-D959-B395-96474CC84EB8</CallerReference>
+            <Config>
+                <Comment>Test comment for subdomain host</Comment>
+            </Config>
+            <ResourceRecordSetCount>4</ResourceRecordSetCount>
+        </HostedZone>
+    </HostedZones>
+    <IsTruncated>false</IsTruncated>
+    <MaxItems>100</MaxItems>
+</ListHostedZonesResponse>`

--- a/route53/route53.go
+++ b/route53/route53.go
@@ -196,6 +196,33 @@ func (r *Route53) GetHostedZone(ID string) (*GetHostedZoneResponse, error) {
 	return out, err
 }
 
+type ListHostedZonesResponse struct {
+	HostedZones []HostedZone `xml:"HostedZones>HostedZone"`
+	Marker      string       `xml:"Marker"`
+	IsTruncated bool         `xml:"IsTruncated"`
+	NextMarker  string       `xml:"NextMarker"`
+	MaxItems    int          `xml:"MaxItems"`
+}
+
+func (r *Route53) ListHostedZones(marker string, maxItems int) (*ListHostedZonesResponse, error) {
+	values := url.Values{}
+
+	if marker != "" {
+		values.Add("marker", marker)
+	}
+
+	if maxItems != 0 {
+		values.Add("maxItems", strconv.Itoa(maxItems))
+	}
+
+	out := &ListHostedZonesResponse{}
+	err := r.query("GET", fmt.Sprintf("/%s/hostedzone/", APIVersion), values, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, err
+}
+
 type GetChangeResponse struct {
 	ChangeInfo ChangeInfo `xml:"ChangeInfo"`
 }

--- a/route53/route53_test.go
+++ b/route53/route53_test.go
@@ -157,6 +157,25 @@ func TestListResourceRecordSets(t *testing.T) {
 	}
 }
 
+func TestListHostedZones(t *testing.T) {
+	testServer := makeTestServer()
+	client := makeClient(testServer)
+	testServer.Response(200, nil, ListHostedZonesExample)
+
+	resp, err := client.ListHostedZones("", 0)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if resp.HostedZones[0].Name != "example.com." {
+		t.Fatalf("bad: %v", resp)
+	}
+
+	if resp.HostedZones[1].Name != "sub.example.com." {
+		t.Fatalf("bad: %v", resp)
+	}
+}
+
 func decode(t *testing.T, r io.Reader, out interface{}) {
 	var buf1 bytes.Buffer
 	var buf2 bytes.Buffer


### PR DESCRIPTION
Adds the following API endpoint

http://docs.aws.amazon.com/Route53/latest/APIReference/API_ListHostedZones.html

This is handy to call the other methods which are based on zone ID. Here we can get a list and filter the zone Id based on the zone name.
