### PR TITLE
ec2: add missing BlockDevice support for Instances() method

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -272,6 +272,15 @@ type RunInstancesResp struct {
 	Instances      []Instance      `xml:"instancesSet>item"`
 }
 
+// BlockDevice represents the association of a block device with an instance.
+type BlockDevice struct {
+	DeviceName          string `xml:"deviceName"`
+	VolumeId            string `xml:"ebs>volumeId"`
+	Status              string `xml:"ebs>status"`
+	AttachTime          string `xml:"ebs>attachTime"`
+	DeleteOnTermination bool   `xml:"ebs>deleteOnTermination"`
+}
+
 // Instance encapsulates a running instance in EC2.
 //
 // See http://goo.gl/OCH8a for more details.
@@ -300,6 +309,7 @@ type Instance struct {
 	SourceDestCheck    bool            `xml:"sourceDestCheck"`
 	SecurityGroups     []SecurityGroup `xml:"groupSet>item"`
 	EbsOptimized       string          `xml:"ebsOptimized"`
+	BlockDevices       []BlockDevice   `xml:"blockDeviceMapping>item"`
 }
 
 // RunInstances starts new instances in EC2.

--- a/ec2/ec2_test.go
+++ b/ec2/ec2_test.go
@@ -375,6 +375,13 @@ func (s *S) TestDescribeInstancesExample1(c *C) {
 	c.Assert(r0i.PrivateDNSName, Equals, "domU-12-31-39-10-56-34.compute-1.internal")
 	c.Assert(r0i.DNSName, Equals, "ec2-174-129-165-232.compute-1.amazonaws.com")
 	c.Assert(r0i.AvailZone, Equals, "us-east-1b")
+
+	b0 := r0i.BlockDevices[0]
+	c.Assert(b0.DeviceName, Equals, "/dev/sda1")
+	c.Assert(b0.VolumeId, Equals, "vol-a082c1c9")
+	c.Assert(b0.Status, Equals, "attached")
+	c.Assert(b0.AttachTime, Equals, "2010-08-17T01:15:21.000Z")
+	c.Assert(b0.DeleteOnTermination, Equals, false)
 }
 
 func (s *S) TestDescribeInstancesExample2(c *C) {


### PR DESCRIPTION
This was missing in the response so there was no way to obtain it. We
can't use the BlockDeviceMapping struct because the response in the
InstancesResp is different than the others. So we add a new
`BlockDevice` struct that represents the Block device response coming
from the instances resp.  The response information can be found here:

http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeInstances.html

In the form of

```
block-device-mapping.attach-time
The attach time for an Amazon EBS volume mapped to the instance (for
example, 2010-09-15T17:15:20.000Z)

Type: DateTime

block-device-mapping.delete-on-termination
Indicates whether the Amazon EBS volume is deleted on instance
termination.

Type: Boolean

block-device-mapping.device-name
The device name (for example, /dev/sdh) for the Amazon EBS volume.

Type: String

block-device-mapping.status
The status for the Amazon EBS volume.

Type: String

Valid values: attaching | attached | detaching | detached

block-device-mapping.volume-id
The volume ID of the Amazon EBS volume.

Type: String
```

The test response was already containing the in the form of

``` xml
  <blockDeviceMapping>
    <item>
      <deviceName>/dev/sda1</deviceName>
      <ebs>
        <volumeId>vol-a082c1c9</volumeId>
        <status>attached</status>
        <attachTime>2010-08-17T01:15:21.000Z</attachTime>
        <deleteOnTermination>false</deleteOnTermination>
      </ebs>
    </item>
  </blockDeviceMapping>
```

Therefore I also included this missing case to the tests.
