### PR TITLE
aws.Auth: Check for AWS_CREDENTIAL_FILE env

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -13,9 +13,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/vaughan0/go-ini"
 	"io/ioutil"
 	"os"
+
+	"github.com/vaughan0/go-ini"
 )
 
 // Region defines the URLs where AWS services may be accessed.
@@ -334,13 +335,16 @@ func SharedAuth() (auth Auth, err error) {
 		profileName = "default"
 	}
 
-	var homeDir = os.Getenv("HOME")
-	if homeDir == "" {
-		err = errors.New("Could not get HOME")
-		return
+	var credentialsFile = os.Getenv("AWS_CREDENTIAL_FILE")
+	if credentialsFile == "" {
+		var homeDir = os.Getenv("HOME")
+		if homeDir == "" {
+			err = errors.New("Could not get HOME")
+			return
+		}
+		credentialsFile = homeDir + "/.aws/credentials"
 	}
 
-	var credentialsFile = homeDir + "/.aws/credentials"
 	file, err := ini.LoadFile(credentialsFile)
 	if err != nil {
 		err = errors.New("Couldn't parse AWS credentials file")


### PR DESCRIPTION
The location of the credentials file was hardcoded
to ~/.aws/credentials.

see: http://docs.aws.amazon.com/IAM/latest/CLIReference/Options.html
