### PR TITLE
autoscaling: Fix TerminationPolicies serialization

### DIFF
--- a/autoscaling/autoscaling.go
+++ b/autoscaling/autoscaling.go
@@ -215,8 +215,8 @@ func (autoscaling *AutoScaling) CreateAutoScalingGroup(options *CreateAutoScalin
 		params["Tag.member."+strconv.Itoa(j+1)+".Value"] = tag.Value
 	}
 
-	if options.TerminationPolicies != nil {
-		params["TerminationPolicies"] = strings.Join(options.TerminationPolicies, ",")
+	for i, v := range options.TerminationPolicies {
+		params["TerminationPolicies.member."+strconv.Itoa(i+1)] = v
 	}
 
 	if options.VPCZoneIdentifier != nil {

--- a/autoscaling/autoscaling_test.go
+++ b/autoscaling/autoscaling_test.go
@@ -62,7 +62,8 @@ func (s *S) Test_CreateAutoScalingGroup(c *C) {
 	c.Assert(req.Form["Action"], DeepEquals, []string{"CreateAutoScalingGroup"})
 	c.Assert(req.Form["InstanceId"], DeepEquals, []string{"i-foo"})
 	c.Assert(req.Form["VPCZoneIdentifier"], DeepEquals, []string{"foo,bar"})
-	c.Assert(req.Form["TerminationPolicies"], DeepEquals, []string{"ClosestToNextInstanceHour,OldestInstance"})
+	c.Assert(req.Form["TerminationPolicies.member.1"], DeepEquals, []string{"ClosestToNextInstanceHour"})
+	c.Assert(req.Form["TerminationPolicies.member.2"], DeepEquals, []string{"OldestInstance"})
 	c.Assert(err, IsNil)
 	c.Assert(resp.RequestId, Equals, "8d798a29-f083-11e1-bdfb-cb223EXAMPLE")
 }


### PR DESCRIPTION
Didn't have the format write in CreateAutoScalingGroup. Updated test + tested in AWS.
