### PR TITLE
ec2: bump version to 2014-06-15

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -127,7 +127,7 @@ type xmlErrors struct {
 var timeNow = time.Now
 
 func (ec2 *EC2) query(params map[string]string, resp interface{}) error {
-	params["Version"] = "2014-05-01"
+	params["Version"] = "2014-06-15"
 	params["Timestamp"] = timeNow().In(time.UTC).Format(time.RFC3339)
 	endpoint, err := url.Parse(ec2.Region.EC2Endpoint)
 	if err != nil {

--- a/ec2/ec2_test.go
+++ b/ec2/ec2_test.go
@@ -1054,7 +1054,7 @@ func (s *S) TestSignatureWithEndpointPath(c *C) {
 	c.Assert(err, IsNil)
 
 	req := testServer.WaitRequest()
-	c.Assert(req.Form["Signature"], DeepEquals, []string{"QmvgkYGn19WirCuCz/jRp3RmRgFwWR5WRkKZ5AZnyXQ="})
+	c.Assert(req.Form["Signature"], DeepEquals, []string{"tyOTQ0c0T5ujskCPTWa5ATMtv7UyErgT339cU8O2+Q8="})
 }
 
 func (s *S) TestAllocateAddressExample(c *C) {


### PR DESCRIPTION
Ran into issues with #95 working as intended because the API version was too low.

I looked for a changelog for the AWS API but couldn't find one anywhere. Is it safe to raise this version according to their compatibility policy?

Also see: https://github.com/hashicorp/terraform/pull/285
