### PR TITLE
skip signing request if no auth secret is present

### DIFF
--- a/s3/sign.go
+++ b/s3/sign.go
@@ -4,10 +4,11 @@ import (
 	"crypto/hmac"
 	"crypto/sha1"
 	"encoding/base64"
-	"github.com/mitchellh/goamz/aws"
 	"log"
 	"sort"
 	"strings"
+
+	"github.com/mitchellh/goamz/aws"
 )
 
 var b64 = base64.StdEncoding
@@ -45,6 +46,11 @@ func sign(auth aws.Auth, method, canonicalPath string, params, headers map[strin
 	// add security token
 	if auth.Token != "" {
 		headers["x-amz-security-token"] = []string{auth.Token}
+	}
+
+	if auth.SecretKey == "" {
+		// no auth secret; skip signing, e.g. for public read-only buckets.
+		return
 	}
 
 	for k, v := range headers {
@@ -111,6 +117,7 @@ func sign(auth aws.Auth, method, canonicalPath string, params, headers map[strin
 	} else {
 		headers["Authorization"] = []string{"AWS " + auth.AccessKey + ":" + string(signature)}
 	}
+
 	if debug {
 		log.Printf("Signature payload: %q", payload)
 		log.Printf("Signature: %q", signature)

--- a/s3/sign_test.go
+++ b/s3/sign_test.go
@@ -9,6 +9,7 @@ import (
 // S3 ReST authentication docs: http://goo.gl/G1LrK
 
 var testAuth = aws.Auth{"0PN5J17HBGZHT7JJ3X82", "uV3F3YluFJax1cknvbcGwgjvx4QpvB+leU8dUj2o", ""}
+var emptyAuth = aws.Auth{"", "", ""}
 
 func (s *S) TestSignExampleObjectGet(c *C) {
 	method := "GET"
@@ -20,6 +21,17 @@ func (s *S) TestSignExampleObjectGet(c *C) {
 	s3.Sign(testAuth, method, path, nil, headers)
 	expected := "AWS 0PN5J17HBGZHT7JJ3X82:xXjDGYUmKxnwqr5KXNPGldn5LbA="
 	c.Assert(headers["Authorization"], DeepEquals, []string{expected})
+}
+
+func (s *S) TestSignExampleObjectGetNoAuth(c *C) {
+	method := "GET"
+	path := "/johnsmith/photos/puppy.jpg"
+	headers := map[string][]string{
+		"Host": {"johnsmith.s3.amazonaws.com"},
+		"Date": {"Tue, 27 Mar 2007 19:36:42 +0000"},
+	}
+	s3.Sign(emptyAuth, method, path, nil, headers)
+	c.Assert(headers["Authorization"], IsNil)
 }
 
 func (s *S) TestSignExampleObjectPut(c *C) {
@@ -54,6 +66,23 @@ func (s *S) TestSignExampleList(c *C) {
 	c.Assert(headers["Authorization"], DeepEquals, []string{expected})
 }
 
+func (s *S) TestSignExampleListNoAuth(c *C) {
+	method := "GET"
+	path := "/johnsmith/"
+	params := map[string][]string{
+		"prefix":   {"photos"},
+		"max-keys": {"50"},
+		"marker":   {"puppy"},
+	}
+	headers := map[string][]string{
+		"Host":       {"johnsmith.s3.amazonaws.com"},
+		"Date":       {"Tue, 27 Mar 2007 19:42:41 +0000"},
+		"User-Agent": {"Mozilla/5.0"},
+	}
+	s3.Sign(emptyAuth, method, path, params, headers)
+	c.Assert(headers["Authorization"], IsNil)
+}
+
 func (s *S) TestSignExampleFetch(c *C) {
 	method := "GET"
 	path := "/johnsmith/"
@@ -67,6 +96,20 @@ func (s *S) TestSignExampleFetch(c *C) {
 	s3.Sign(testAuth, method, path, params, headers)
 	expected := "AWS 0PN5J17HBGZHT7JJ3X82:thdUi9VAkzhkniLj96JIrOPGi0g="
 	c.Assert(headers["Authorization"], DeepEquals, []string{expected})
+}
+
+func (s *S) TestSignExampleFetchNoAuth(c *C) {
+	method := "GET"
+	path := "/johnsmith/"
+	params := map[string][]string{
+		"acl": {""},
+	}
+	headers := map[string][]string{
+		"Host": {"johnsmith.s3.amazonaws.com"},
+		"Date": {"Tue, 27 Mar 2007 19:44:46 +0000"},
+	}
+	s3.Sign(emptyAuth, method, path, params, headers)
+	c.Assert(headers["Authorization"], IsNil)
 }
 
 func (s *S) TestSignExampleDelete(c *C) {


### PR DESCRIPTION
This allows goamz to be used without auth for publicly-readable buckets. Added tests for the 3 common read operations.

(some go formatting changes also included, I can strip them out if you want a smaller patch.)
