### PR TITLE
autoscaling: Support passing the IAMInstanceProfile through to a launch configuration

### DIFF
--- a/autoscaling/autoscaling.go
+++ b/autoscaling/autoscaling.go
@@ -110,12 +110,13 @@ type LoadBalancerName struct {
 }
 
 type LaunchConfiguration struct {
-	ImageId        string          `xml:"member>ImageId"`
-	InstanceType   string          `xml:"member>InstanceType"`
-	KeyName        string          `xml:"member>KeyName"`
-	Name           string          `xml:"member>LaunchConfigurationName"`
-	SecurityGroups []SecurityGroup `xml:"member>SecurityGroups"`
-	UserData       []byte          `xml:"member>UserData"`
+	IamInstanceProfile string          `xml:"member>IamInstanceProfile"`
+	ImageId            string          `xml:"member>ImageId"`
+	InstanceType       string          `xml:"member>InstanceType"`
+	KeyName            string          `xml:"member>KeyName"`
+	Name               string          `xml:"member>LaunchConfigurationName"`
+	SecurityGroups     []SecurityGroup `xml:"member>SecurityGroups"`
+	UserData           []byte          `xml:"member>UserData"`
 }
 
 type AutoScalingGroup struct {


### PR DESCRIPTION
References:
- https://github.com/hashicorp/terraform/issues/323
- https://github.com/mitchellh/goamz/issues/73

It wasn't clear to me how to write a test for this, since the instance profile has to exist for you to reference it. If you have any feedback on that, I'd be happy to implement the test too.
