### PR TITLE
Don't include some params into signpath while preparing request.

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -706,22 +706,6 @@ func (s3 *S3) prepare(req *request) error {
 			req.path = "/" + req.path
 		}
 		req.signpath = req.path
-		// signpath includes subresource, if present: "?acl", "?delete", "?location", "?logging", or "?torrent"
-		if req.params["acl"] != nil {
-			req.signpath += "?acl"
-		}
-		if req.params["delete"] != nil {
-			req.signpath += "?delete"
-		}
-		if req.params["location"] != nil {
-			req.signpath += "?location"
-		}
-		if req.params["logging"] != nil {
-			req.signpath += "?logging"
-		}
-		if req.params["torrent"] != nil {
-			req.signpath += "?torrent"
-		}
 
 		if req.bucket != "" {
 			req.baseurl = s3.Region.S3BucketEndpoint

--- a/s3/sign.go
+++ b/s3/sign.go
@@ -18,6 +18,7 @@ var b64 = base64.StdEncoding
 
 var s3ParamsToSign = map[string]bool{
 	"acl":                          true,
+	"delete":                       true,
 	"location":                     true,
 	"logging":                      true,
 	"notification":                 true,


### PR DESCRIPTION
These params would be added automatically by sign function from sign.go.

This fixes MultiDel method (incorrect signature prior to this change).
