### PR TITLE
Add option IamInstanceProfile to CreateLaunchConfiguration for supporting aws role base AC

### DIFF
--- a/autoscaling/autoscaling.go
+++ b/autoscaling/autoscaling.go
@@ -237,7 +237,7 @@ func (autoscaling *AutoScaling) CreateAutoScalingGroup(options *CreateAutoScalin
 
 // The CreateLaunchConfiguration request parameters
 type CreateLaunchConfiguration struct {
-    IamInstanceProfile  string
+	IamInstanceProfile  string
 	ImageId             string
 	InstanceId          string
 	InstanceType        string


### PR DESCRIPTION
Code changes to support aws autoscaling CreatingLaunchConfiguration with iam_instance_profile
- add IamInstanceProfile to CreateLaunchConfiguration type
- add options.IamInstanceProfile to CreateLaunchConfiguration()
