### PR TITLE
Autoscaling: added terminate instance in autoscaling group, corrected AutoScalingGroup

### DIFF
--- a/autoscaling/autoscaling.go
+++ b/autoscaling/autoscaling.go
@@ -4,12 +4,12 @@ package autoscaling
 
 import (
 	"encoding/xml"
+	"github.com/mitchellh/goamz/aws"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 	"time"
-	"github.com/mitchellh/goamz/aws"
 )
 
 // The AutoScaling type encapsulates operations operations with the autoscaling endpoint.
@@ -116,29 +116,28 @@ type LaunchConfiguration struct {
 	UserData           []byte          `xml:"member>UserData"`
 }
 
-
 const (
-	Pending = "Pending"
-	PendingWait = "Pending:Wait"
-	PendingProceed = "Pending:Proceed"
-	Quarantined = "Quarantined"
-	InService = "InService"
-	Terminating = "Terminating"
-	TerminatingWait = "Terminating:Wait"
+	Pending            = "Pending"
+	PendingWait        = "Pending:Wait"
+	PendingProceed     = "Pending:Proceed"
+	Quarantined        = "Quarantined"
+	InService          = "InService"
+	Terminating        = "Terminating"
+	TerminatingWait    = "Terminating:Wait"
 	TerminatingProceed = "Terminating:Proceed"
-	Terminated = "Terminated"
-	Detaching = "Detaching"
-	Detached = "Detached"
-	EnteringStandby = "EnteringStandby"
-	Standby = "Standby"
+	Terminated         = "Terminated"
+	Detaching          = "Detaching"
+	Detached           = "Detached"
+	EnteringStandby    = "EnteringStandby"
+	Standby            = "Standby"
 )
 
 type Instance struct {
-	AvailabilityZone 	    	string 		`xml:"AvailabilityZone"`
-	HealthStatus			 	string 		`xml:"HealthStatus"`
-	InstanceId			 		string 		`xml:"InstanceId"`
-	LaunchConfigurationName 	string      `xml:"LaunchConfigurationName"`
-	LifecycleState				string  	`xml:"LifecycleState"`
+	AvailabilityZone        string `xml:"AvailabilityZone"`
+	HealthStatus            string `xml:"HealthStatus"`
+	InstanceId              string `xml:"InstanceId"`
+	LaunchConfigurationName string `xml:"LaunchConfigurationName"`
+	LifecycleState          string `xml:"LifecycleState"`
 }
 
 type AutoScalingGroup struct {
@@ -147,7 +146,7 @@ type AutoScalingGroup struct {
 	DesiredCapacity         int                `xml:"member>DesiredCapacity"`
 	HealthCheckGracePeriod  int                `xml:"member>HealthCheckGracePeriod"`
 	HealthCheckType         string             `xml:"member>HealthCheckType"`
-	Instances               []Instance   	   `xml:"member>Instances>member"`
+	Instances               []Instance         `xml:"member>Instances>member"`
 	LaunchConfigurationName string             `xml:"member>LaunchConfigurationName"`
 	LoadBalancerNames       []LoadBalancerName `xml:"member>LoadBalancerNames"`
 	MaxSize                 int                `xml:"member>MaxSize"`
@@ -502,8 +501,8 @@ func (autoscaling *AutoScaling) UpdateAutoScalingGroup(options *UpdateAutoScalin
 // Destroy
 // The TerminateInstanceInAutoScalingGroup request parameters
 type TerminateInstanceInAutoScalingGroup struct {
-	InstanceId              		string
-	ShouldDecrementDesiredCapacity 	string
+	InstanceId                     string
+	ShouldDecrementDesiredCapacity string
 }
 
 func (autoscaling *AutoScaling) TerminateInstanceInAutoScalingGroup(options *TerminateInstanceInAutoScalingGroup) (resp *TerminateInstanceResp, err error) {
@@ -522,25 +521,24 @@ func (autoscaling *AutoScaling) TerminateInstanceInAutoScalingGroup(options *Ter
 	return
 }
 
-
 // Responses
 
-type Activity struct{
-	ActivityId 				string  `xml:"member"`
-	AutoScalingGroupName 	string 	`xml:"member"`
-	Cause 					string 	`xml:"member"`
-	Description 			string 	`xml:"member"`
-	Details 				string 	`xml:"member"`
-	EndTime 				string 	`xml:"member"`
-	Progress 				string 	`xml:"member"`
-	StartTime 				string 	`xml:"member"`
-	StatusCode 				string 	`xml:"member"`
-	StatusMessage 			string 	`xml:"member"`
+type Activity struct {
+	ActivityId           string `xml:"member"`
+	AutoScalingGroupName string `xml:"member"`
+	Cause                string `xml:"member"`
+	Description          string `xml:"member"`
+	Details              string `xml:"member"`
+	EndTime              string `xml:"member"`
+	Progress             string `xml:"member"`
+	StartTime            string `xml:"member"`
+	StatusCode           string `xml:"member"`
+	StatusMessage        string `xml:"member"`
 }
 
 type TerminateInstanceResp struct {
-	RequestId         string             `xml:"ResponseMetadata>RequestId"`
-	Activity 		  Activity 			 `xml:"DescribeAutoScalingGroupsResult>Activity`
+	RequestId string   `xml:"ResponseMetadata>RequestId"`
+	Activity  Activity `xml:"DescribeAutoScalingGroupsResult>Activity`
 }
 
 type SimpleResp struct {


### PR DESCRIPTION
Hi @mitchellh,

A couple of small things:
- Added TerminateInstanceInAutoscalingGroup,
- The AutoScalingGroup struct now catches the info about the instances in the autoscaling group.

Thanks!
