### PR TITLE
Update route53.go package desription.

### DIFF
--- a/route53/route53.go
+++ b/route53/route53.go
@@ -1,4 +1,4 @@
-// The elb package provides types and functions for interaction with the AWS
+// The route53 package provides types and functions for interaction with the AWS
 // Route53 service
 package route53
 


### PR DESCRIPTION
Wrong package name. `elb` -> `route53`
