### PR TITLE
adding support for s3 service resource, only supports Buckets response element

### DIFF
--- a/s3/s3test/server.go
+++ b/s3/s3test/server.go
@@ -226,6 +226,13 @@ var pathRegexp = regexp.MustCompile("/(([^/]+)(/(.*))?)?")
 
 // resourceForURL returns a resource object for the given URL.
 func (srv *Server) resourceForURL(u *url.URL) (r resource) {
+
+	if u.Path == "/" {
+		return serviceResource{
+			buckets: srv.buckets,
+		}
+	}
+
 	m := pathRegexp.FindStringSubmatch(u.Path)
 	if m == nil {
 		fatalf(404, "InvalidURI", "Couldn't parse the specified URI")
@@ -282,6 +289,37 @@ func (nullResource) post(a *action) interface{}   { return notAllowed() }
 func (nullResource) delete(a *action) interface{} { return notAllowed() }
 
 const timeFormat = "2006-01-02T15:04:05.000Z07:00"
+
+type serviceResource struct {
+	buckets map[string]*bucket
+}
+
+func (serviceResource) put(a *action) interface{}    { return notAllowed() }
+func (serviceResource) post(a *action) interface{}   { return notAllowed() }
+func (serviceResource) delete(a *action) interface{} { return notAllowed() }
+
+// GET on an s3 service lists the buckets.
+// http://docs.aws.amazon.com/AmazonS3/latest/API/RESTServiceGET.html
+func (r serviceResource) get(a *action) interface{} {
+	type respBucket struct {
+		Name string
+	}
+
+	type response struct {
+		Buckets []respBucket `xml:">Bucket"`
+	}
+
+	resp := response{}
+
+	for _, bucketPtr := range r.buckets {
+		bkt := respBucket{
+			Name: bucketPtr.name,
+		}
+		resp.Buckets = append(resp.Buckets, bkt)
+	}
+
+	return &resp
+}
 
 type bucketResource struct {
 	name   string


### PR DESCRIPTION
This allows test server to support 'List Buckets' operation on S3 client.

Signed-off-by: Peter Ellis Jones pete@peterellisjones.com
