### PR TITLE
Added Support for Private Hosted Zones

### DIFF
--- a/route53/responses_test.go
+++ b/route53/responses_test.go
@@ -120,3 +120,21 @@ var ListHostedZonesExample = `<?xml version="1.0" encoding="utf-8"?>
     <IsTruncated>false</IsTruncated>
     <MaxItems>100</MaxItems>
 </ListHostedZonesResponse>`
+
+var AssociateVPCWithHostedZoneExample = `<?xml version="1.0" encoding="UTF-8"?>
+<AssociateVPCWithHostedZoneResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+   <ChangeInfo>
+      <Id>/change/abcd</Id>
+      <Status>PENDING</Status>
+      <SubmittedAt>2014</SubmittedAt>
+   </ChangeInfo>
+</AssociateVPCWithHostedZoneResponse>`
+
+var DisassociateVPCFromHostedZoneExample = `<?xml version="1.0" encoding="UTF-8"?>
+<DisassociateVPCFromHostedZoneResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+   <ChangeInfo>
+      <Id>/change/abcd</Id>
+      <Status>PENDING</Status>
+      <SubmittedAt>2014</SubmittedAt>
+   </ChangeInfo>
+</DisassociateVPCFromHostedZoneResponse>`

--- a/route53/route53_test.go
+++ b/route53/route53_test.go
@@ -176,6 +176,38 @@ func TestListHostedZones(t *testing.T) {
 	}
 }
 
+func TestAssociateVPCWithHostedZone(t *testing.T) {
+	testServer := makeTestServer()
+	client := makeClient(testServer)
+	testServer.Response(200, nil, AssociateVPCWithHostedZoneExample)
+	req := &AssociateVPCWithHostedZoneRequest{VPC: VPC{ID: "vpc", Region: "us-west-1"}}
+	resp, err := client.AssociateVPCWithHostedZone("abc", req)
+
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if resp.ChangeInfo.ID != "/change/abcd" {
+		t.Fatalf("bad: %v", resp)
+	}
+}
+
+func TestDisassociateVPCFromHostedZone(t *testing.T) {
+	testServer := makeTestServer()
+	client := makeClient(testServer)
+	testServer.Response(200, nil, DisassociateVPCFromHostedZoneExample)
+	req := &DisassociateVPCFromHostedZoneRequest{VPC: VPC{ID: "vpc", Region: "us-west-1"}}
+	resp, err := client.DisassociateVPCFromHostedZone("abc", req)
+
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if resp.ChangeInfo.ID != "/change/abcd" {
+		t.Fatalf("bad: %v", resp)
+	}
+}
+
 func decode(t *testing.T, r io.Reader, out interface{}) {
 	var buf1 bytes.Buffer
 	var buf2 bytes.Buffer


### PR DESCRIPTION
Amazon recently announced support for [Private Hosted Zones](http://docs.aws.amazon.com/Route53/latest/APIReference/actions-on-zones-private.html), I added support for the below endpoints
- POST CreateHostedZone (Private)
- POST AssociateVPCWithHostedZone
- POST DisassociateVPCFromHostedZone
- GET GetHostedZone (Private)
- GET ListHostedZones (Public and Private)

This is my first time writing go code. I apologize in advance for any blunders :)
