### PR TITLE
Fix doc typo: Rename SecurityGroupNames -> SecurityGroupIds

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -1934,7 +1934,7 @@ func SecurityGroupNames(names ...string) []SecurityGroup {
 	return g
 }
 
-// SecurityGroupNames is a convenience function that
+// SecurityGroupIds is a convenience function that
 // returns a slice of security groups with the given ids.
 func SecurityGroupIds(ids ...string) []SecurityGroup {
 	g := make([]SecurityGroup, len(ids))


### PR DESCRIPTION
Was going over the code when I noticed this documentation typo. No rocket science but still a tiny improvement to this great project : )
