### PR TITLE
Create/Delete/Describe for network acl

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -2494,8 +2494,15 @@ type NetworkAcl struct {
 	VpcId          string                  `xml:"vpcId"`
 	Default        string                  `xml:"default"`
 	EntrySet       []NetworkAclEntry       `xml:"entrySet>item"`
-	AssociationSet []NetworkAclAssociation `xml:"AssociationSet>item"`
+	AssociationSet []NetworkAclAssociation `xml:"associationSet>item"`
 	Tags           []Tag                   `xml:"tagSet>item"`
+}
+
+// NetworkAclAssociation
+type NetworkAclAssociation struct {
+	NetworkAclAssociationId string `xml:"networkAclAssociationId"`
+	NetworkAclId            string `xml:"networkAclId"`
+	SubnetId                string `xml:"subnetId"`
 }
 
 // NetworkAclEntry represent a rule within NetworkAcl
@@ -2525,13 +2532,6 @@ type PortRange struct {
 type NetworkAclsResp struct {
 	RequestId   string       `xml:"requestId"`
 	NetworkAcls []NetworkAcl `xml:"networkAclSet>item"`
-}
-
-// NetworkAclAssociation
-type NetworkAclAssociation struct {
-	NetworkAclAssociationId string `xml:"networkAclAssociationId"`
-	NetworkAclId            string `xml:"networkAclId"`
-	SubnetId                string `xml:"subnetId"`
 }
 
 // VPC represents a single VPC.
@@ -2803,6 +2803,27 @@ func (ec2 *EC2) DeleteNetworkAclEntry(id string, ruleNumber int, egress bool) (r
 	params["Egress"] = strconv.FormatBool(egress)
 
 	resp = &DeleteNetworkAclEntryResp{}
+	err = ec2.query(params, resp)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+type ReplaceNetworkAclAssociationResponse struct {
+	RequestId        string `xml:"requestId"`
+	NewAssociationId string `xml:"newAssociationId"`
+}
+
+// ReplaceNetworkAclAssociation changes which network ACL a subnet is associated with.
+//
+// http://goo.gl/ar0MH5
+func (ec2 *EC2) ReplaceNetworkAclAssociation(associationId string, networkAclId string) (resp *ReplaceNetworkAclAssociationResponse, err error) {
+	params := makeParams("ReplaceNetworkAclAssociation")
+	params["NetworkAclId"] = networkAclId
+	params["AssociationId"] = associationId
+
+	resp = &ReplaceNetworkAclAssociationResponse{}
 	err = ec2.query(params, resp)
 	if err != nil {
 		return nil, err

--- a/ec2/ec2_test.go
+++ b/ec2/ec2_test.go
@@ -1403,7 +1403,7 @@ func (s *S) TestCreateNetworkAclEntry(c *C) {
 
 	c.Assert(req.Form["NetworkAclId"], DeepEquals, []string{"acl-11ad4878"})
 	c.Assert(req.Form["RuleNumber"], DeepEquals, []string{"32767"})
-	c.Assert(req.Form["Protocol"], DeepEquals, []string{ "6" })
+	c.Assert(req.Form["Protocol"], DeepEquals, []string{"6"})
 	c.Assert(req.Form["RuleAction"], DeepEquals, []string{"deny"})
 	c.Assert(req.Form["Egress"], DeepEquals, []string{"true"})
 	c.Assert(req.Form["CidrBlock"], DeepEquals, []string{"0.0.0.0/0"})
@@ -1422,5 +1422,17 @@ func (s *S) TestDescribeNetworkAcls(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(resp.RequestId, Equals, "59dbff89-35bd-4eac-99ed-be587EXAMPLE")
 	c.Assert(resp.NetworkAcls, HasLen, 2)
+	c.Assert(resp.NetworkAcls[1].AssociationSet, HasLen, 2)
+	c.Assert(resp.NetworkAcls[1].AssociationSet[0].NetworkAclAssociationId, Equals, "aclassoc-5c659635")
+	c.Assert(resp.NetworkAcls[1].AssociationSet[0].NetworkAclId, Equals, "acl-5d659634")
+	c.Assert(resp.NetworkAcls[1].AssociationSet[0].SubnetId, Equals, "subnet-ff669596")
+}
 
+func (s *S) TestReplaceNetworkAclAssociation(c *C) {
+	testServer.Response(200, nil, ReplaceNetworkAclAssociationResponseExample)
+
+	resp, err := s.ec2.ReplaceNetworkAclAssociation("aclassoc-e5b95c8c", "acl-5fb85d36")
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "59dbff89-35bd-4eac-99ed-be587EXAMPLE")
+	c.Assert(resp.NewAssociationId, Equals, "aclassoc-17b85d7e")
 }

--- a/ec2/responses_test.go
+++ b/ec2/responses_test.go
@@ -1198,3 +1198,10 @@ var DescribeNetworkAclsExample = `
  </networkAclSet>
 </DescribeNetworkAclsResponse>
 `
+
+var ReplaceNetworkAclAssociationResponseExample = `
+<ReplaceNetworkAclAssociationResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
+   <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> 
+   <newAssociationId>aclassoc-17b85d7e</newAssociationId>
+</ReplaceNetworkAclAssociationResponse>
+`


### PR DESCRIPTION
Implemented following APIs for network acls. 

[CreateNetworkACL](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-CreateNetworkAcl.html)
[CreateNetworkAclEntry](http://goo.gl/BtXhtj)
[DescribeNetworkAcls](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeNetworkAcls.html)
[DeleteNetworkAcl](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-DeleteNetworkAcl.html)
[DeleteNetworkAclEntry](http://goo.gl/moQbE2)
[ReplaceNetworkAclAssociation](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-ReplaceNetworkAclAssociation.html)

This is required for adding network acl support in Terraform.
