### PR TITLE
s3: fix signed URLs with temp tokens

### DIFF
--- a/s3/sign.go
+++ b/s3/sign.go
@@ -87,6 +87,10 @@ func sign(auth aws.Auth, method, canonicalPath string, params, headers map[strin
 		expires = true
 		date = v[0]
 		params["AWSAccessKeyId"] = []string{auth.AccessKey}
+		// When using temporary credentials the token must be included in the URL
+		if auth.Token != "" {
+			params["x-amz-security-token"] = []string{auth.Token}
+		}
 	}
 
 	sarray = sarray[0:0]


### PR DESCRIPTION
When using temporary credentials (e.g. IAM roles) it's necessary to include the token in the URL when signing.
