### PR TITLE
Fix for Aliasing

### DIFF
--- a/route53/route53.go
+++ b/route53/route53.go
@@ -105,6 +105,20 @@ func (r *Route53) query(method, path string, req, resp interface{}) error {
 			bodyBuf = &newBuf
 		}
 
+		// http://docs.aws.amazon.com/Route53/latest/APIReference/CreateAliasRRSAPI.html
+		if reflect.Indirect(reflect.ValueOf(req)).Type().Name() == "ChangeResourceRecordSetsRequest" {
+			if len(req.(ChangeResourceRecordSetsRequest).Changes) > 1 {
+				for _, change := range req.(ChangeResourceRecordSetsRequest).Changes {
+					if change.Record.AliasTarget != nil {
+						replace := change.Record.Type + "</Type><TTL>0</TTL>"
+						var newBuf bytes.Buffer
+						newBuf.WriteString(strings.Replace(bodyBuf.String(), replace, change.Record.Type+"</Type>", -1))
+						bodyBuf = &newBuf
+					}
+				}
+			}
+		}
+
 		body = bodyBuf
 	}
 


### PR DESCRIPTION
Fix for Aliasing
https://github.com/mitchellh/goamz/blob/master/route53/route53.go#L101

According to Creating Alias Resource Record Sets documentation (http://docs.aws.amazon.com/Route53/latest/APIReference/CreateAliasRRSAPI.html), we do not include the XML element `<TTL>` when we want to create an alias but the present code inserts this element when the `query` is called by `ChangeResourceRecordSets`.

So in case we need to create an alias with load balancer, we need to take out `<TTL>` element. Kind of dirty but it works. Without this, I keep getting error of `client.ChangeResourceRecordSets error:Request failed, got status code: 400. Response: <?xml version="1.0"?>`
