### PR TITLE
Add `HostedZoneNameID` for route53 Alias Resource Record Sets

### DIFF
--- a/elb/elb.go
+++ b/elb/elb.go
@@ -4,11 +4,12 @@ package elb
 
 import (
 	"encoding/xml"
-	"github.com/mitchellh/goamz/aws"
 	"net/http"
 	"net/url"
 	"strconv"
 	"time"
+
+	"github.com/mitchellh/goamz/aws"
 )
 
 // The ELB type encapsulates operations operations with the elb endpoint.
@@ -281,6 +282,7 @@ type LoadBalancer struct {
 	Instances         []Instance         `xml:"Instances>member"`
 	HealthCheck       HealthCheck        `xml:"HealthCheck"`
 	AvailabilityZones []AvailabilityZone `xml:"AvailabilityZones"`
+	HostedZoneNameID  string             `xml:"CanonicalHostedZoneNameID"`
 	DNSName           string             `xml:"DNSName"`
 	SecurityGroups    []string           `xml:"SecurityGroups>member"`
 	Scheme            string             `xml:"Scheme"`


### PR DESCRIPTION
Add `HostedZoneNameID` for route53 Alias Resource Record Sets

There are some missing values from `DescribeLoadBalancers`:
http://docs.aws.amazon.com/ElasticLoadBalancing/latest/APIReference/API_DescribeLoadBalancers.html

Especially, `CanonicalHostedZoneNameID` (`Hosted Zone ID` of elastic load balancer) is needed when creating route53 hosted zone with `Alias Resource Record Sets` as explained below:

> Use the DescribeLoadBalancers action, which is described in the "Actions" chapter of the Elastic Load Balancing API Reference.

http://docs.aws.amazon.com/Route53/latest/APIReference/CreateWeightedAliasRRSAPI.html
