### PR TITLE
Fix parameter

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -526,7 +526,7 @@ func (ec2 *EC2) DescribeInstanceStatus(options *DescribeInstanceStatus, filter *
 		params["IncludeAllInstances"] = "true"
 	}
 	if len(options.InstanceIds) > 0 {
-		addParamsList(params, "InstanceIds", options.InstanceIds)
+		addParamsList(params, "InstanceId", options.InstanceIds)
 	}
 	if options.MaxResults > 0 {
 		params["MaxResults"] = strconv.FormatInt(options.MaxResults, 10)


### PR DESCRIPTION
http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceStatus.html  

shows that `InstanceId.N` does not suffixes `s` when passed as a parameter. 

Try running the following code and see the error message:

``` go
// DescribeInstanceStatus describes EC2 instance status by instance ID.
func DescribeInstanceStatus(client *ec2.EC2, instanceID string) (ec2.InstanceStatusSet, error) {
    desc := ec2.DescribeInstanceStatus{
        InstanceIds:         []string{instanceID},
        IncludeAllInstances: true,
    }
    resp, err := client.DescribeInstanceStatus(&desc, ec2.NewFilter())
    if err != nil {
        return ec2.InstanceStatusSet{}, err
    }
    return resp.InstanceStatus[0], nil
}
```

`addParamsList(params, "InstanceIds", options.InstanceIds)` returns error message: 

```
The parameter InstanceIds is not recognized (UnknownParameter)
```

`addParamsList(params, "InstanceId", options.InstanceIds)` without `s` works, as expected.

Thanks!
