### PR TITLE
ec2: Add NextToken to DescribeInstanceStatusResp

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -509,6 +509,7 @@ type InstanceStatusSet struct {
 }
 
 type DescribeInstanceStatusResp struct {
+	NextToken      string              `xml:"nextToken"`
 	RequestId      string              `xml:"requestId"`
 	InstanceStatus []InstanceStatusSet `xml:"instanceStatusSet>item"`
 }


### PR DESCRIPTION
In order to use pagination for EC2 responses, we need the `nextToken`
node in the XML response.