### PR TITLE
Add back `HostedZoneNameID`

### DIFF
--- a/elb/elb.go
+++ b/elb/elb.go
@@ -277,6 +277,7 @@ type LoadBalancer struct {
 	Instances         []Instance  `xml:"Instances>member"`
 	HealthCheck       HealthCheck `xml:"HealthCheck"`
 	AvailabilityZones []string    `xml:"AvailabilityZones>member"`
+	HostedZoneNameID  string      `xml:"CanonicalHostedZoneNameID"`
 	DNSName           string      `xml:"DNSName"`
 	SecurityGroups    []string    `xml:"SecurityGroups>member"`
 	Scheme            string      `xml:"Scheme"`


### PR DESCRIPTION
https://github.com/mitchellh/goamz/pull/159 is omitted by the new pull request https://github.com/mitchellh/goamz/pull/181

You need `HostedZoneNameID` to automate elastic load balancing in AWS. Could you add this back? The new pull request is breaking our ELB automation. Thanks!
