### PR TITLE
Refresh authentication tokens when they expire

### DIFF
--- a/autoscaling/autoscaling_test.go
+++ b/autoscaling/autoscaling_test.go
@@ -23,7 +23,10 @@ var testServer = testutil.NewHTTPServer()
 
 func (s *S) SetUpSuite(c *C) {
 	testServer.Start()
-	auth := aws.Auth{"abc", "123", ""}
+	auth := aws.Auth{
+		AccessKey: "abc",
+		SecretKey: "123",
+	}
 	s.autoscaling = autoscaling.NewWithClient(auth, aws.Region{AutoScalingEndpoint: testServer.URL}, testutil.DefaultClient)
 }
 

--- a/autoscaling/sign.go
+++ b/autoscaling/sign.go
@@ -18,8 +18,8 @@ func sign(auth aws.Auth, method, path string, params map[string]string, host str
 	params["AWSAccessKeyId"] = auth.AccessKey
 	params["SignatureVersion"] = "2"
 	params["SignatureMethod"] = "HmacSHA256"
-	if auth.Token != "" {
-		params["SecurityToken"] = auth.Token
+	if token := auth.Token(); token != "" {
+		params["SecurityToken"] = token
 	}
 
 	var sarray []string

--- a/ec2/ec2_test.go
+++ b/ec2/ec2_test.go
@@ -22,7 +22,10 @@ var testServer = testutil.NewHTTPServer()
 
 func (s *S) SetUpSuite(c *C) {
 	testServer.Start()
-	auth := aws.Auth{"abc", "123", ""}
+	auth := aws.Auth{
+		AccessKey: "abc",
+		SecretKey: "123",
+	}
 	s.ec2 = ec2.NewWithClient(
 		auth,
 		aws.Region{EC2Endpoint: testServer.URL},

--- a/ec2/sign.go
+++ b/ec2/sign.go
@@ -18,8 +18,8 @@ func sign(auth aws.Auth, method, path string, params map[string]string, host str
 	params["AWSAccessKeyId"] = auth.AccessKey
 	params["SignatureVersion"] = "2"
 	params["SignatureMethod"] = "HmacSHA256"
-	if auth.Token != "" {
-		params["SecurityToken"] = auth.Token
+	if token := auth.Token(); token != "" {
+		params["SecurityToken"] = token
 	}
 
 	// AWS specifies that the parameters in a signed request must

--- a/ec2/sign_test.go
+++ b/ec2/sign_test.go
@@ -8,7 +8,10 @@ import (
 
 // EC2 ReST authentication docs: http://goo.gl/fQmAN
 
-var testAuth = aws.Auth{"user", "secret", ""}
+var testAuth = aws.Auth{
+	AccessKey: "user",
+	SecretKey: "secret",
+}
 
 func (s *S) TestBasicSignature(c *C) {
 	params := map[string]string{}
@@ -62,7 +65,7 @@ func (s *S) TestSignatureExample1(c *C) {
 		"Version":   "2007-11-07",
 		"Action":    "ListDomains",
 	}
-	ec2.Sign(aws.Auth{"access", "secret", ""}, "GET", "/", params, "sdb.amazonaws.com")
+	ec2.Sign(aws.Auth{AccessKey: "access", SecretKey: "secret"}, "GET", "/", params, "sdb.amazonaws.com")
 	expected := "okj96/5ucWBSc1uR2zXVfm6mDHtgfNv657rRtt/aunQ="
 	c.Assert(params["Signature"], Equals, expected)
 }

--- a/elb/elb_test.go
+++ b/elb/elb_test.go
@@ -22,7 +22,10 @@ var testServer = testutil.NewHTTPServer()
 
 func (s *S) SetUpSuite(c *C) {
 	testServer.Start()
-	auth := aws.Auth{"abc", "123", ""}
+	auth := aws.Auth{
+		AccessKey: "abc",
+		SecretKey: "123",
+	}
 	s.elb = elb.NewWithClient(auth, aws.Region{ELBEndpoint: testServer.URL}, testutil.DefaultClient)
 }
 

--- a/elb/sign.go
+++ b/elb/sign.go
@@ -18,8 +18,8 @@ func sign(auth aws.Auth, method, path string, params map[string]string, host str
 	params["AWSAccessKeyId"] = auth.AccessKey
 	params["SignatureVersion"] = "2"
 	params["SignatureMethod"] = "HmacSHA256"
-	if auth.Token != "" {
-		params["SecurityToken"] = auth.Token
+	if token := auth.Token(); token != "" {
+		params["SecurityToken"] = token
 	}
 
 	var sarray []string

--- a/exp/mturk/mturk_test.go
+++ b/exp/mturk/mturk_test.go
@@ -23,7 +23,10 @@ var testServer = testutil.NewHTTPServer()
 
 func (s *S) SetUpSuite(c *C) {
 	testServer.Start()
-	auth := aws.Auth{"abc", "123", ""}
+	auth := aws.Auth{
+		AccessKey: "abc",
+		SecretKey: "123",
+	}
 	u, err := url.Parse(testServer.URL)
 	if err != nil {
 		panic(err.Error())

--- a/exp/mturk/sign_test.go
+++ b/exp/mturk/sign_test.go
@@ -8,7 +8,10 @@ import (
 
 // Mechanical Turk REST authentication docs: http://goo.gl/wrzfn
 
-var testAuth = aws.Auth{"user", "secret", ""}
+var testAuth = aws.Auth{
+	AccessKey: "user",
+	SecretKey: "secret",
+}
 
 // == fIJy9wCApBNL2R4J2WjJGtIBFX4=
 func (s *S) TestBasicSignature(c *C) {

--- a/exp/sdb/sdb_test.go
+++ b/exp/sdb/sdb_test.go
@@ -22,7 +22,10 @@ var testServer = testutil.NewHTTPServer()
 
 func (s *S) SetUpSuite(c *C) {
 	testServer.Start()
-	auth := aws.Auth{"abc", "123", ""}
+	auth := aws.Auth{
+		AccessKey: "abc",
+		SecretKey: "123",
+	}
 	s.sdb = sdb.New(auth, aws.Region{SDBEndpoint: testServer.URL})
 }
 

--- a/exp/sdb/sign.go
+++ b/exp/sdb/sign.go
@@ -31,8 +31,8 @@ func sign(auth aws.Auth, method, path string, params url.Values, headers http.He
 	params["AWSAccessKeyId"] = []string{auth.AccessKey}
 	params["SignatureVersion"] = []string{"2"}
 	params["SignatureMethod"] = []string{"HmacSHA256"}
-	if auth.Token != "" {
-		params["SecurityToken"] = []string{auth.Token}
+	if token := auth.Token(); token != "" {
+		params["SecurityToken"] = []string{token}
 	}
 
 	// join up all the incoming params

--- a/exp/sdb/sign_test.go
+++ b/exp/sdb/sign_test.go
@@ -8,7 +8,10 @@ import (
 
 // SimpleDB ReST authentication docs: http://goo.gl/CaY81
 
-var testAuth = aws.Auth{"access-key-id-s8eBOWuU", "secret-access-key-UkQjTLd9", ""}
+var testAuth = aws.Auth{
+	AccessKey: "access-key-id-s8eBOWuU",
+	SecretKey: "secret-access-key-UkQjTLd9",
+}
 
 func (s *S) TestSignExampleDomainCreate(c *C) {
 	method := "GET"

--- a/exp/sns/sns_test.go
+++ b/exp/sns/sns_test.go
@@ -22,7 +22,10 @@ var testServer = testutil.NewHTTPServer()
 
 func (s *S) SetUpSuite(c *C) {
 	testServer.Start()
-	auth := aws.Auth{"abc", "123", ""}
+	auth := aws.Auth{
+		AccessKey: "abc",
+		SecretKey: "123",
+	}
 	s.sns = sns.New(auth, aws.Region{SNSEndpoint: testServer.URL})
 }
 

--- a/iam/iam_test.go
+++ b/iam/iam_test.go
@@ -23,7 +23,10 @@ var testServer = testutil.NewHTTPServer()
 
 func (s *S) SetUpSuite(c *C) {
 	testServer.Start()
-	auth := aws.Auth{"abc", "123", ""}
+	auth := aws.Auth{
+		AccessKey: "abc",
+		SecretKey: "123",
+	}
 	s.iam = iam.NewWithClient(auth, aws.Region{IAMEndpoint: testServer.URL}, testutil.DefaultClient)
 }
 

--- a/iam/sign.go
+++ b/iam/sign.go
@@ -18,8 +18,8 @@ func sign(auth aws.Auth, method, path string, params map[string]string, host str
 	params["AWSAccessKeyId"] = auth.AccessKey
 	params["SignatureVersion"] = "2"
 	params["SignatureMethod"] = "HmacSHA256"
-	if auth.Token != "" {
-		params["SecurityToken"] = auth.Token
+	if token := auth.Token(); token != "" {
+		params["SecurityToken"] = token
 	}
 
 	var sarray []string

--- a/rds/rds_test.go
+++ b/rds/rds_test.go
@@ -22,7 +22,7 @@ var testServer = testutil.NewHTTPServer()
 
 func (s *S) SetUpSuite(c *C) {
 	testServer.Start()
-	auth := aws.Auth{"abc", "123", ""}
+	auth := aws.Auth{AccessKey: "abc", SecretKey: "123"}
 	s.rds = rds.NewWithClient(auth, aws.Region{RdsEndpoint: testServer.URL}, testutil.DefaultClient)
 }
 

--- a/rds/sign.go
+++ b/rds/sign.go
@@ -18,8 +18,8 @@ func sign(auth aws.Auth, method, path string, params map[string]string, host str
 	params["AWSAccessKeyId"] = auth.AccessKey
 	params["SignatureVersion"] = "2"
 	params["SignatureMethod"] = "HmacSHA256"
-	if auth.Token != "" {
-		params["SecurityToken"] = auth.Token
+	if token := auth.Token(); token != "" {
+		params["SecurityToken"] = token
 	}
 
 	var sarray []string

--- a/route53/route53_test.go
+++ b/route53/route53_test.go
@@ -26,7 +26,10 @@ func makeTestServer() *testutil.HTTPServer {
 }
 
 func makeClient(server *testutil.HTTPServer) *Route53 {
-	auth := aws.Auth{"abc", "123", ""}
+	auth := aws.Auth{
+		AccessKey: "abc",
+		SecretKey: "123",
+	}
 	return NewWithClient(auth, aws.Region{Route53Endpoint: server.URL}, testutil.DefaultClient)
 }
 

--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -28,7 +28,10 @@ var testServer = testutil.NewHTTPServer()
 
 func (s *S) SetUpSuite(c *C) {
 	testServer.Start()
-	auth := aws.Auth{"abc", "123", ""}
+	auth := aws.Auth{
+		AccessKey: "abc",
+		SecretKey: "123",
+	}
 	s.s3 = s3.New(auth, aws.Region{Name: "faux-region-1", S3Endpoint: testServer.URL})
 }
 

--- a/s3/sign.go
+++ b/s3/sign.go
@@ -45,8 +45,8 @@ func sign(auth aws.Auth, method, canonicalPath string, params, headers map[strin
 	var sarray []string
 
 	// add security token
-	if auth.Token != "" {
-		headers["x-amz-security-token"] = []string{auth.Token}
+	if token := auth.Token(); token != "" {
+		headers["x-amz-security-token"] = []string{token}
 	}
 
 	if auth.SecretKey == "" {


### PR DESCRIPTION
This changes the Auth API slightly to fix token refresh when using the AWS instance metadata service to fetch credentials.

If breaking the API is an issue, Auth.token could be switch back to public, but then there's the risk of some parts of the code using the field directly instead of the method.

Right now, errors when reloading are ignored. One could add an error to the return values of Token() if that's considered an issue.
