### PR TITLE
Ommitting RecordResourceSet.TTL when empty

### DIFF
--- a/route53/route53.go
+++ b/route53/route53.go
@@ -328,7 +328,7 @@ type ListResourceRecordSetsResponse struct {
 type ResourceRecordSet struct {
 	Name          string       `xml:"Name"`
 	Type          string       `xml:"Type"`
-	TTL           int          `xml:"TTL"`
+	TTL           int          `xml:"TTL,omitempty"`
 	Records       []string     `xml:"ResourceRecords>ResourceRecord>Value,omitempty"`
 	SetIdentifier string       `xml:"SetIdentifier,omitempty"`
 	Weight        int          `xml:"Weight,omitempty"`


### PR DESCRIPTION
Amazon does not allow TTL to be specified for Alias records. Unless TTL
is `omitempty`, an invalid xml payload will be generated for Alias
record creation/deletion.
