### PR TITLE
Add a ListUsers method for iam

### DIFF
--- a/iam/iam.go
+++ b/iam/iam.go
@@ -134,6 +134,28 @@ func (iam *IAM) CreateUser(name, path string) (*CreateUserResp, error) {
 	return resp, nil
 }
 
+// UsersResp Response to a ListUsers request.
+//
+// See http://goo.gl/iBxBBb for more details.
+type UsersResp struct {
+	Users     []User `xml:"ListUsersResult>Users>member"`
+	RequestId string `xml:"ResponseMetadata>RequestId"`
+}
+
+// Users list all the users.
+//
+// See http://goo.gl/iBxBBb for more details.
+func (iam *IAM) Users() (*UsersResp, error) {
+	params := map[string]string{
+		"Action": "ListUsers",
+	}
+	resp := new(UsersResp)
+	if err := iam.query(params, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
 // Response for GetUser requests.
 //
 // See http://goo.gl/ZnzRN for more details.

--- a/iam/iam_test.go
+++ b/iam/iam_test.go
@@ -163,6 +163,30 @@ func (s *S) TestListGroupsWithoutPathPrefix(c *C) {
 	c.Assert(ok, Equals, false)
 }
 
+func (s *S) TestListUsers(c *C) {
+	testServer.Response(200, nil, ListUsersExample)
+	resp, err := s.iam.Users()
+	values := testServer.WaitRequest().URL.Query()
+	c.Assert(values.Get("Action"), Equals, "ListUsers")
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "7a62c49f-347e-4fc4-9331-6e8eEXAMPLE")
+	expected := []iam.User{
+		{
+			Path: "/division_abc/subdivision_xyz/engineering/",
+			Name: "Andrew",
+			Id:   "AID2MAB8DPLSRHEXAMPLE",
+			Arn:  "arn:aws:iam::123456789012:user/division_abc/subdivision_xyz/engineering/Andrew",
+		},
+		{
+			Path: "/division_abc/subdivision_xyz/engineering/",
+			Name: "Jackie",
+			Id:   "AIDIODR4TAW7CSEXAMPLE",
+			Arn:  "arn:aws:iam::123456789012:user/division_abc/subdivision_xyz/engineering/Jackie",
+		},
+	}
+	c.Assert(resp.Users, DeepEquals, expected)
+}
+
 func (s *S) TestCreateAccessKey(c *C) {
 	testServer.Response(200, nil, CreateAccessKeyExample)
 	resp, err := s.iam.CreateAccessKey("Bob")

--- a/iam/responses_test.go
+++ b/iam/responses_test.go
@@ -91,6 +91,35 @@ var ListGroupsExample = `
 </ListGroupsResponse>
 `
 
+var ListUsersExample = `
+<ListUsersResponse>
+  <ListUsersResult>
+    <Users>
+      <member>
+        <UserId>AID2MAB8DPLSRHEXAMPLE</UserId>
+        <Path>/division_abc/subdivision_xyz/engineering/</Path>
+        <UserName>Andrew</UserName>
+        <Arn>arn:aws:iam::123456789012:user/division_abc/subdivision_xyz/engineering/Andrew</Arn>
+        <CreateDate>2012-09-05T19:38:48Z</CreateDate>
+        <PasswordLastUsed>2014-09-08T21:47:36Z</PasswordLastUsed>
+      </member>
+      <member>
+        <UserId>AIDIODR4TAW7CSEXAMPLE</UserId>
+        <Path>/division_abc/subdivision_xyz/engineering/</Path>
+        <UserName>Jackie</UserName>
+        <Arn>arn:aws:iam::123456789012:user/division_abc/subdivision_xyz/engineering/Jackie</Arn>
+        <CreateDate>2014-04-09T15:43:45Z</CreateDate>
+        <PasswordLastUsed>2014-09-24T16:18:07Z</PasswordLastUsed>
+      </member>
+    </Users>
+    <IsTruncated>false</IsTruncated>
+  </ListUsersResult>
+  <ResponseMetadata>
+    <RequestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</RequestId>
+  </ResponseMetadata>
+</ListUsersResponse>
+`
+
 var RequestIdExample = `
 <AddUserToGroupResponse>
    <ResponseMetadata>


### PR DESCRIPTION
I am working on a little script that needed the [`ListUsers`](http://docs.aws.amazon.com/IAM/latest/APIReference/API_ListUsers.html) method.  Note, I'm new to `go` so I just tried to match what I saw already, and tried not to offend `golint` as much as possible.
