### PR TITLE
Fixed incorrect api for deletion of customer gateway

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -3215,16 +3215,16 @@ func (ec2 *EC2) DescribeCustomerGateways(ids []string, filter *Filter) (resp *De
 	return
 }
 
-type DeleteCustomerGatewaysResp struct {
+type DeleteCustomerGatewayResp struct {
 	RequestId string `xml:"requestId"`
 	Return    bool   `xml:"return"`
 }
 
-func (ec2 *EC2) DeleteCustomerGateways(customerGatewayId string) (resp *DeleteCustomerGatewaysResp, err error) {
-	params := makeParams("DeleteCustomerGateways")
+func (ec2 *EC2) DeleteCustomerGateway(customerGatewayId string) (resp *DeleteCustomerGatewayResp, err error) {
+	params := makeParams("DeleteCustomerGateway")
 	params["CustomerGatewayId"] = customerGatewayId
 
-	resp = &DeleteCustomerGatewaysResp{}
+	resp = &DeleteCustomerGatewayResp{}
 	err = ec2.query(params, resp)
 	if err != nil {
 		return nil, err

--- a/ec2/ec2_test.go
+++ b/ec2/ec2_test.go
@@ -1478,7 +1478,7 @@ func (s *S) TestDescribeCustomerGateways(c *C) {
 	c.Assert(resp.CustomerGateways[1].CustomerGatewayId, Equals, "cgw-b4dc3962")
 }
 
-func (s *S) TestDeleteCustomerGateways(c *C) {
+func (s *S) TestDeleteCustomerGateway(c *C) {
 	testServer.Response(200, nil, DeleteCustomerGatewayResponseExample)
 
 	resp, err := s.ec2.DeleteCustomerGateways("cgw-b4dc3961")


### PR DESCRIPTION
Fixes bug in https://github.com/mitchellh/goamz/pull/177.
```DeleteCustomerGateways``` should have been ```DeleteCustomerGateway```..note the extra ```s```. 