### PR TITLE
Aws mfa support

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -377,6 +377,7 @@ func SharedAuth() (auth Auth, err error) {
 
 	auth.AccessKey = profile["aws_access_key_id"]
 	auth.SecretKey = profile["aws_secret_access_key"]
+	auth.Token = profile["aws_session_token"]
 
 	if auth.AccessKey == "" {
 		err = errors.New("AWS_ACCESS_KEY_ID not found in environment in credentials file")

--- a/aws/aws_test.go
+++ b/aws/aws_test.go
@@ -135,6 +135,30 @@ func (s *S) TestSharedAuth(c *C) {
 	c.Assert(auth, Equals, aws.Auth{SecretKey: "secret", AccessKey: "access"})
 }
 
+func (s *S) TestSharedAuthCredentialsWithToken(c *C) {
+        os.Clearenv()
+        os.Setenv("AWS_PROFILE", "bar")
+
+        d, err := ioutil.TempDir("", "")
+        if err != nil {
+                panic(err)
+        }
+        defer os.RemoveAll(d)
+
+        err = os.Mkdir(d+"/.aws", 0755)
+        if err != nil {
+                panic(err)
+        }
+
+        ioutil.WriteFile(d+"/.aws/credentials", []byte("[bar]\naws_access_key_id = access\naws_secret_access_key = secret\naws_session_token = token\n", 0644)
+        os.Setenv("HOME", d)
+
+        auth, err := aws.SharedAuth()
+        c.Assert(err, IsNil)
+        c.Assert(auth, Equals, aws.Auth{SecretKey: "secret", AccessKey: "access", Token: "token"})
+}
+
+
 func (s *S) TestEnvAuthNoSecret(c *C) {
 	os.Clearenv()
 	_, err := aws.EnvAuth()


### PR DESCRIPTION
Support for AWS multifactor authentication via the "SharedAuth" credentials file mechanism.  This is already supported for environment variable AWS_SECURITY_TOKEN.  Tested with ebs and instance builders in us-east-1; unit test added.