### PR TITLE
plumb through RootDeviceName on ec2 Instances

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -313,6 +313,7 @@ type Instance struct {
 	SecurityGroups     []SecurityGroup `xml:"groupSet>item"`
 	EbsOptimized       string          `xml:"ebsOptimized"`
 	BlockDevices       []BlockDevice   `xml:"blockDeviceMapping>item"`
+	RootDeviceName     string          `xml:"rootDeviceName"`
 }
 
 // RunInstances starts new instances in EC2.

--- a/ec2/ec2_test.go
+++ b/ec2/ec2_test.go
@@ -375,6 +375,7 @@ func (s *S) TestDescribeInstancesExample1(c *C) {
 	c.Assert(r0i.PrivateDNSName, Equals, "domU-12-31-39-10-56-34.compute-1.internal")
 	c.Assert(r0i.DNSName, Equals, "ec2-174-129-165-232.compute-1.amazonaws.com")
 	c.Assert(r0i.AvailZone, Equals, "us-east-1b")
+	c.Assert(r0i.RootDeviceName, Equals, "/dev/sda1")
 
 	b0 := r0i.BlockDevices[0]
 	c.Assert(b0.DeviceName, Equals, "/dev/sda1")

--- a/ec2/ec2_test.go
+++ b/ec2/ec2_test.go
@@ -1481,7 +1481,7 @@ func (s *S) TestDescribeCustomerGateways(c *C) {
 func (s *S) TestDeleteCustomerGateway(c *C) {
 	testServer.Response(200, nil, DeleteCustomerGatewayResponseExample)
 
-	resp, err := s.ec2.DeleteCustomerGateways("cgw-b4dc3961")
+	resp, err := s.ec2.DeleteCustomerGateway("cgw-b4dc3961")
 
 	req := testServer.WaitRequest()
 	c.Assert(req.Form["CustomerGatewayId"], DeepEquals, []string{"cgw-b4dc3961"})


### PR DESCRIPTION
It's already in the response, just need to add it to the struct.

Will allow us to skip root devices for https://github.com/hashicorp/terraform/issues/859 