### PR TITLE
Support StorageType parameter in RDS requests

### DIFF
--- a/rds/rds.go
+++ b/rds/rds.go
@@ -19,7 +19,7 @@ type Rds struct {
 	httpClient *http.Client
 }
 
-const APIVersion = "2013-09-09"
+const APIVersion = "2014-10-31"
 
 // New creates a new Rds instance.
 func New(auth aws.Auth, region aws.Region) *Rds {

--- a/rds/rds.go
+++ b/rds/rds.go
@@ -93,6 +93,7 @@ func makeParams(action string) map[string]string {
 type DBInstance struct {
 	Address                    string        `xml:"Endpoint>Address"`
 	AllocatedStorage           int           `xml:"AllocatedStorage"`
+	StorageType                string        `xml:"StorageType"`
 	AvailabilityZone           string        `xml:"AvailabilityZone"`
 	BackupRetentionPeriod      int           `xml:"BackupRetentionPeriod"`
 	DBInstanceClass            string        `xml:"DBInstanceClass"`
@@ -170,6 +171,7 @@ type Parameter struct {
 // The CreateDBInstance request parameters
 type CreateDBInstance struct {
 	AllocatedStorage           int
+	StorageType                string
 	AvailabilityZone           string
 	BackupRetentionPeriod      int
 	DBInstanceClass            string
@@ -201,6 +203,10 @@ func (rds *Rds) CreateDBInstance(options *CreateDBInstance) (resp *SimpleResp, e
 
 	if options.SetAllocatedStorage {
 		params["AllocatedStorage"] = strconv.Itoa(options.AllocatedStorage)
+	}
+
+	if options.StorageType != "" {
+		params["StorageType"] = options.StorageType
 	}
 
 	if options.SetBackupRetentionPeriod {

--- a/rds/rds_test.go
+++ b/rds/rds_test.go
@@ -138,7 +138,7 @@ func (s *S) Test_DescribeDBInstances(c *C) {
 	c.Assert(resp.RequestId, Equals, "01b2685a-b978-11d3-f272-7cd6cce12cc5")
 	c.Assert(resp.DBInstances[0].DBName, Equals, "mysampledb")
 	c.Assert(resp.DBInstances[0].DBSecurityGroupNames, DeepEquals, []string{"my-db-secgroup"})
-	c.Assert(resp.DBInstances[0].DBParameterGroupName, Equals, "my-db-paramgroup")
+	c.Assert(resp.DBInstances[0].DBParameterGroupName, Equals, "default.mysql5.6")
 	c.Assert(resp.DBInstances[1].VpcSecurityGroupIds, DeepEquals, []string{"my-vpc-secgroup"})
 }
 
@@ -206,7 +206,7 @@ func (s *S) Test_DescribeDBParameters(c *C) {
 
 	options := rds.DescribeDBParameters{
 		DBParameterGroupName: "mydbparamgroup3",
-		Source: "user",
+		Source:               "user",
 	}
 
 	resp, err := s.rds.DescribeDBParameters(&options)
@@ -379,7 +379,7 @@ func (s *S) Test_ModifyDBParameterGroup(c *C) {
 
 	options := rds.ModifyDBParameterGroup{
 		DBParameterGroupName: "mydbparamgroup3",
-		Parameters:           []rds.Parameter{
+		Parameters: []rds.Parameter{
 			rds.Parameter{
 				ApplyMethod:    "immediate",
 				ParameterName:  "character_set_server",

--- a/rds/rds_test.go
+++ b/rds/rds_test.go
@@ -44,6 +44,7 @@ func (s *S) Test_CreateDBInstance(c *C) {
 		EngineVersion:              "",
 		DBName:                     "5.6.13",
 		AllocatedStorage:           10,
+		StorageType:                "gp2",
 		MasterUsername:             "foobar",
 		MasterUserPassword:         "bazbarbaz",
 		DBInstanceClass:            "db.m1.small",
@@ -58,6 +59,7 @@ func (s *S) Test_CreateDBInstance(c *C) {
 
 	c.Assert(req.Form["Action"], DeepEquals, []string{"CreateDBInstance"})
 	c.Assert(req.Form["Engine"], DeepEquals, []string{"mysql"})
+	c.Assert(req.Form["StorageType"], DeepEquals, []string{"gp2"})
 	c.Assert(req.Form["DBSecurityGroups.member.1"], DeepEquals, []string{"foo"})
 	c.Assert(err, IsNil)
 	c.Assert(resp.RequestId, Equals, "523e3218-afc7-11c3-90f5-f90431260ab4")
@@ -139,6 +141,7 @@ func (s *S) Test_DescribeDBInstances(c *C) {
 	c.Assert(resp.DBInstances[0].DBName, Equals, "mysampledb")
 	c.Assert(resp.DBInstances[0].DBSecurityGroupNames, DeepEquals, []string{"my-db-secgroup"})
 	c.Assert(resp.DBInstances[0].DBParameterGroupName, Equals, "default.mysql5.6")
+	c.Assert(resp.DBInstances[0].StorageType, Equals, "gp2")
 	c.Assert(resp.DBInstances[1].VpcSecurityGroupIds, DeepEquals, []string{"my-vpc-secgroup"})
 }
 

--- a/rds/responses_test.go
+++ b/rds/responses_test.go
@@ -9,11 +9,11 @@ var ErrorDump = `
 
 // http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DescribeDBInstances.html
 var DescribeDBInstancesExample = `
-<DescribeDBInstancesResponse xmlns="http://rds.amazonaws.com/doc/2013-09-09/">
+<DescribeDBInstancesResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
   <DescribeDBInstancesResult>
     <DBInstances>
       <DBInstance>
-        <BackupRetentionPeriod>1</BackupRetentionPeriod>
+        <BackupRetentionPeriod>7</BackupRetentionPeriod>
         <MultiAZ>false</MultiAZ>
         <DBInstanceStatus>available</DBInstanceStatus>
         <VpcSecurityGroups/>
@@ -29,7 +29,7 @@ var DescribeDBInstancesExample = `
         <DBParameterGroups>
           <DBParameterGroup>
             <ParameterApplyStatus>in-sync</ParameterApplyStatus>
-            <DBParameterGroupName>my-db-paramgroup</DBParameterGroupName>
+            <DBParameterGroupName>default.mysql5.6</DBParameterGroupName>
           </DBParameterGroup>
         </DBParameterGroups>
         <Endpoint>
@@ -58,7 +58,7 @@ var DescribeDBInstancesExample = `
         <DBInstanceClass>db.t1.micro</DBInstanceClass>
       </DBInstance>
       <DBInstance>
-        <BackupRetentionPeriod>1</BackupRetentionPeriod>
+        <BackupRetentionPeriod>7</BackupRetentionPeriod>
         <MultiAZ>false</MultiAZ>
         <DBInstanceStatus>available</DBInstanceStatus>
         <VpcSecurityGroups>
@@ -111,10 +111,10 @@ var DescribeDBInstancesExample = `
 `
 
 var CreateDBInstanceExample = `
-<CreateDBInstanceResponse xmlns="http://rds.amazonaws.com/doc/2013-09-09/">
+<CreateDBInstanceResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
   <CreateDBInstanceResult>
     <DBInstance>
-      <BackupRetentionPeriod>1</BackupRetentionPeriod>
+      <BackupRetentionPeriod>7</BackupRetentionPeriod>
       <DBInstanceStatus>creating</DBInstanceStatus>
       <MultiAZ>false</MultiAZ>
       <VpcSecurityGroups/>
@@ -161,10 +161,10 @@ var CreateDBInstanceExample = `
 `
 
 var DeleteDBInstanceExample = `
-<DeleteDBInstanceResponse xmlns="http://rds.amazonaws.com/doc/2013-09-09/">
+<DeleteDBInstanceResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
   <DeleteDBInstanceResult>
     <DBInstance>
-      <BackupRetentionPeriod>2</BackupRetentionPeriod>
+      <BackupRetentionPeriod>7</BackupRetentionPeriod>
       <DBInstanceStatus>deleting</DBInstanceStatus>
       <MultiAZ>false</MultiAZ>
       <VpcSecurityGroups/>
@@ -212,10 +212,11 @@ var DeleteDBInstanceExample = `
   <ResponseMetadata>
     <RequestId>7369556f-b70d-11c3-faca-6ba18376ea1b</RequestId>
   </ResponseMetadata>
-</DeleteDBInstanceResponse>`
+</DeleteDBInstanceResponse>
+`
 
 var DescribeDBSecurityGroupsExample = `
-<DescribeDBSecurityGroupsResponse xmlns="http://rds.amazonaws.com/doc/2013-09-09/">
+<DescribeDBSecurityGroupsResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
   <DescribeDBSecurityGroupsResult>
     <DBSecurityGroups>
       <DBSecurityGroup>
@@ -261,17 +262,19 @@ var DescribeDBSecurityGroupsExample = `
   <ResponseMetadata>
     <RequestId>b76e692c-b98c-11d3-a907-5a2c468b9cb0</RequestId>
   </ResponseMetadata>
-</DescribeDBSecurityGroupsResponse>`
+</DescribeDBSecurityGroupsResponse>
+`
 
 var DeleteDBSecurityGroupExample = `
-<DeleteDBSecurityGroupResponse xmlns="http://rds.amazonaws.com/doc/2013-09-09/">
+<DeleteDBSecurityGroupResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
   <ResponseMetadata>
     <RequestId>7aec7454-ba25-11d3-855b-576787000e19</RequestId>
   </ResponseMetadata>
 </DeleteDBSecurityGroupResponse>
 `
+
 var CreateDBSecurityGroupExample = `
-<CreateDBSecurityGroupResponse xmlns="http://rds.amazonaws.com/doc/2013-09-09/">
+<CreateDBSecurityGroupResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
   <CreateDBSecurityGroupResult>
     <DBSecurityGroup>
       <EC2SecurityGroups/>
@@ -288,7 +291,7 @@ var CreateDBSecurityGroupExample = `
 `
 
 var AuthorizeDBSecurityGroupIngressExample = `
-<AuthorizeDBSecurityGroupIngressResponse xmlns="http://rds.amazonaws.com/doc/2013-09-09/">
+<AuthorizeDBSecurityGroupIngressResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
   <AuthorizeDBSecurityGroupIngressResult>
     <DBSecurityGroup>
       <EC2SecurityGroups>
@@ -329,7 +332,7 @@ var AuthorizeDBSecurityGroupIngressExample = `
 `
 
 var DescribeDBSubnetGroupsExample = `
-<DescribeDBSubnetGroupsResponse xmlns="http://rds.amazonaws.com/doc/2013-09-09/">
+<DescribeDBSubnetGroupsResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
   <DescribeDBSubnetGroupsResult>
     <DBSubnetGroups>
       <DBSubnetGroup>
@@ -397,7 +400,7 @@ var DescribeDBSubnetGroupsExample = `
 `
 
 var DeleteDBSubnetGroupExample = `
-<DeleteDBSubnetGroupResponse xmlns="http://rds.amazonaws.com/doc/2013-09-09/">
+<DeleteDBSubnetGroupResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
   <ResponseMetadata>
     <RequestId>6295e5ab-bbf3-11d3-f4c6-37db295f7674</RequestId>
   </ResponseMetadata>
@@ -405,7 +408,7 @@ var DeleteDBSubnetGroupExample = `
 `
 
 var CreateDBSubnetGroupExample = `
-<CreateDBSubnetGroupResponse xmlns="http://rds.amazonaws.com/doc/2013-09-09/">
+<CreateDBSubnetGroupResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
   <CreateDBSubnetGroupResult>
     <DBSubnetGroup>
       <VpcId>vpc-33dc97ea</VpcId>
@@ -439,7 +442,7 @@ var CreateDBSubnetGroupExample = `
 `
 
 var DescribeDBSnapshotsExample = `
-<DescribeDBSnapshotsResponse xmlns="http://rds.amazonaws.com/doc/2013-09-09/">
+<DescribeDBSnapshotsResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
   <DescribeDBSnapshotsResult>
     <DBSnapshots>
       <DBSnapshot>
@@ -502,10 +505,10 @@ var DescribeDBSnapshotsExample = `
 `
 
 var RestoreDBInstanceFromDBSnapshotExample = `
-<RestoreDBInstanceFromDBSnapshotResponse xmlns="http://rds.amazonaws.com/doc/2013-09-09/">
+<RestoreDBInstanceFromDBSnapshotResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
   <RestoreDBInstanceFromDBSnapshotResult>
     <DBInstance>
-      <BackupRetentionPeriod>2</BackupRetentionPeriod>
+      <BackupRetentionPeriod>7</BackupRetentionPeriod>
       <MultiAZ>false</MultiAZ>
       <DBInstanceStatus>creating</DBInstanceStatus>
       <VpcSecurityGroups/>
@@ -553,7 +556,7 @@ var CreateDBParameterGroupExample = `
 <CreateDBParameterGroupResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
   <CreateDBParameterGroupResult>
     <DBParameterGroup>
-      <DBParameterGroupFamily>mysql5.6</DBParameterGroupFamily>
+      <DBParameterGroupFamily>mysql5.1</DBParameterGroupFamily>
       <Description>My new DB Parameter Group</Description>
       <DBParameterGroupName>mydbparamgroup3</DBParameterGroupName>
     </DBParameterGroup>

--- a/rds/responses_test.go
+++ b/rds/responses_test.go
@@ -54,6 +54,7 @@ var DescribeDBInstancesExample = `
         <AutoMinorVersionUpgrade>true</AutoMinorVersionUpgrade>
         <InstanceCreateTime>2014-01-29T22:58:24.231Z</InstanceCreateTime>
         <AllocatedStorage>5</AllocatedStorage>
+        <StorageType>gp2</StorageType>
         <MasterUsername>myawsuser</MasterUsername>
         <DBInstanceClass>db.t1.micro</DBInstanceClass>
       </DBInstance>


### PR DESCRIPTION
This parameter wasn't available in API version 2013-09-09, so I updated to 2014-10-31. I could not find any incompatible changes, but all the test examples were updated for good measure.

With this parameter supported, general purpose SSD storage types can be provisioned.