### PR TITLE
Add backward-compatible support for AWS_SESSION_TOKEN

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -403,6 +403,9 @@ func EnvAuth() (auth Auth, err error) {
 	}
 
 	auth.Token = os.Getenv("AWS_SECURITY_TOKEN")
+	if os.Getenv("AWS_SESSION_TOKEN") != "" {
+		auth.Token = os.Getenv("AWS_SESSION_TOKEN")
+	}
 
 	if auth.AccessKey == "" {
 		err = errors.New("AWS_ACCESS_KEY_ID or AWS_ACCESS_KEY not found in environment")

--- a/aws/aws_test.go
+++ b/aws/aws_test.go
@@ -167,6 +167,27 @@ func (s *S) TestEnvAuthWithToken(c *C) {
 	c.Assert(auth, Equals, aws.Auth{SecretKey: "secret", AccessKey: "access", Token: "token"})
 }
 
+func (s *S) TestEnvAuthWithSessionToken(c *C) {
+	os.Clearenv()
+	os.Setenv("AWS_SECRET_ACCESS_KEY", "secret")
+	os.Setenv("AWS_ACCESS_KEY_ID", "access")
+	os.Setenv("AWS_SESSION_TOKEN", "token")
+	auth, err := aws.EnvAuth()
+	c.Assert(err, IsNil)
+	c.Assert(auth, Equals, aws.Auth{SecretKey: "secret", AccessKey: "access", Token: "token"})
+}
+
+func (s *S) TestEnvAuthWithBothTokens(c *C) {
+	os.Clearenv()
+	os.Setenv("AWS_SECRET_ACCESS_KEY", "secret")
+	os.Setenv("AWS_ACCESS_KEY_ID", "access")
+	os.Setenv("AWS_SECURITY_TOKEN", "security")
+	os.Setenv("AWS_SESSION_TOKEN", "session")
+	auth, err := aws.EnvAuth()
+	c.Assert(err, IsNil)
+	c.Assert(auth, Equals, aws.Auth{SecretKey: "secret", AccessKey: "access", Token: "session"})
+}
+
 func (s *S) TestEnvAuthAlt(c *C) {
 	os.Clearenv()
 	os.Setenv("AWS_SECRET_KEY", "secret")


### PR DESCRIPTION
This is closing #207 