### PR TITLE
Add option to copy S3 objects from one bucket to another.

### DIFF
--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -290,6 +290,26 @@ func (s *S) TestCopy(c *C) {
 	c.Assert(req.Header["X-Amz-Acl"], DeepEquals, []string{"private"})
 }
 
+func (s *S) TestCopyToAnotherBucket(c *C) {
+	testServer.Response(200, nil, "")
+
+	b := s.s3.Bucket("bucket")
+	nb := s.s3.Bucket("new-bucket")
+	err := b.CopyToAnotherBucket(
+		"old/file",
+		nb,
+		"new/file",
+		s3.Private,
+	)
+	c.Assert(err, IsNil)
+
+	req := testServer.WaitRequest()
+	c.Assert(req.Method, Equals, "PUT")
+	c.Assert(req.URL.Path, Equals, "/new-bucket/new/file")
+	c.Assert(req.Header["X-Amz-Copy-Source"], DeepEquals, []string{"/bucket/old/file"})
+	c.Assert(req.Header["X-Amz-Acl"], DeepEquals, []string{"private"})
+}
+
 func (s *S) TestPlusInURL(c *C) {
 	testServer.Response(200, nil, "")
 


### PR DESCRIPTION
Ability to copy S3 objects from one bucket to another.

http://docs.aws.amazon.com/AmazonS3/latest/dev/CopyingObjectUsingREST.html