### PR TITLE
expose ASG termination policies

### DIFF
--- a/autoscaling/autoscaling.go
+++ b/autoscaling/autoscaling.go
@@ -135,6 +135,7 @@ type AutoScalingGroup struct {
 	Status                  string     `xml:"Status"`
 	Tags                    []Tag      `xml:"Tags>member"`
 	VPCZoneIdentifier       string     `xml:"VPCZoneIdentifier"`
+	TerminationPolicies     []string   `xml:"TerminationPolicies>member"`
 }
 
 // ----------------------------------------------------------------------------

--- a/autoscaling/autoscaling_test.go
+++ b/autoscaling/autoscaling_test.go
@@ -108,6 +108,7 @@ func (s *S) Test_DescribeAutoScalingGroups(c *C) {
 	c.Assert(resp.RequestId, Equals, "0f02a07d-b677-11e2-9eb0-dd50EXAMPLE")
 	c.Assert(resp.AutoScalingGroups[0].Name, Equals, "my-test-asg-lbs")
 	c.Assert(resp.AutoScalingGroups[0].LaunchConfigurationName, Equals, "my-test-lc")
+	c.Assert(resp.AutoScalingGroups[0].TerminationPolicies[0], Equals, "Default")
 }
 
 func (s *S) Test_DescribeLaunchConfigurations(c *C) {


### PR DESCRIPTION
we support writing it but not reading it, which makes terraform a little
confused about the whole deal.