### PR TITLE
Support MFA token from AWS config file

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -377,6 +377,7 @@ func SharedAuth() (auth Auth, err error) {
 
 	auth.AccessKey = profile["aws_access_key_id"]
 	auth.SecretKey = profile["aws_secret_access_key"]
+	auth.Token = profile["aws_session_token"]
 
 	if auth.AccessKey == "" {
 		err = errors.New("AWS_ACCESS_KEY_ID not found in environment in credentials file")

--- a/aws/aws_test.go
+++ b/aws/aws_test.go
@@ -104,12 +104,13 @@ func (s *S) TestSharedAuthDefaultCredentials(c *C) {
 		panic(err)
 	}
 
-	ioutil.WriteFile(d+"/.aws/credentials", []byte("[default]\naws_access_key_id = access\naws_secret_access_key = secret\n"), 0644)
+	ioutil.WriteFile(d+"/.aws/credentials",
+		[]byte("[default]\naws_access_key_id = access\naws_secret_access_key = secret\naws_session_token = token"), 0644)
 	os.Setenv("HOME", d)
 
 	auth, err := aws.SharedAuth()
 	c.Assert(err, IsNil)
-	c.Assert(auth, Equals, aws.Auth{SecretKey: "secret", AccessKey: "access"})
+	c.Assert(auth, Equals, aws.Auth{SecretKey: "secret", AccessKey: "access", Token: "token"})
 }
 
 func (s *S) TestSharedAuth(c *C) {
@@ -127,12 +128,13 @@ func (s *S) TestSharedAuth(c *C) {
 		panic(err)
 	}
 
-	ioutil.WriteFile(d+"/.aws/credentials", []byte("[bar]\naws_access_key_id = access\naws_secret_access_key = secret\n"), 0644)
+	ioutil.WriteFile(d+"/.aws/credentials",
+		[]byte("[bar]\naws_access_key_id = access\naws_secret_access_key = secret\naws_session_token = token"), 0644)
 	os.Setenv("HOME", d)
 
 	auth, err := aws.SharedAuth()
 	c.Assert(err, IsNil)
-	c.Assert(auth, Equals, aws.Auth{SecretKey: "secret", AccessKey: "access"})
+	c.Assert(auth, Equals, aws.Auth{SecretKey: "secret", AccessKey: "access", Token: "token"})
 }
 
 func (s *S) TestEnvAuthNoSecret(c *C) {


### PR DESCRIPTION
There's already a support for the MFA token through ENV variables, so this simple change is adding support for the same from config files.

Have a look to http://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs
just to confirm correctness of variable name according to Amazon's practices.
