### PR TITLE
Deprecate AWS_SECURITY_TOKEN in favor of AWS_SESSION_TOKEN

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -402,7 +402,10 @@ func EnvAuth() (auth Auth, err error) {
 		auth.SecretKey = os.Getenv("AWS_SECRET_KEY")
 	}
 
-	auth.Token = os.Getenv("AWS_SECURITY_TOKEN")
+	auth.Token = os.Getenv("AWS_SESSION_TOKEN")
+	if auth.Token == "" {
+		auth.Token = os.Getenv("AWS_SECURITY_TOKEN")
+	}
 
 	if auth.AccessKey == "" {
 		err = errors.New("AWS_ACCESS_KEY_ID or AWS_ACCESS_KEY not found in environment")

--- a/aws/aws_test.go
+++ b/aws/aws_test.go
@@ -161,7 +161,23 @@ func (s *S) TestEnvAuthWithToken(c *C) {
 	os.Clearenv()
 	os.Setenv("AWS_SECRET_ACCESS_KEY", "secret")
 	os.Setenv("AWS_ACCESS_KEY_ID", "access")
-	os.Setenv("AWS_SECURITY_TOKEN", "token")
+	os.Setenv("AWS_SESSION_TOKEN", "token")
+	auth, err := aws.EnvAuth()
+	c.Assert(err, IsNil)
+	c.Assert(auth, Equals, aws.Auth{SecretKey: "secret", AccessKey: "access", Token: "token"})
+}
+
+func (s *S) TestEnvAuthWithDeprecatedVars(c *C) {
+	os.Clearenv()
+	os.Setenv("AWS_SECRET_ACCESS_KEY", "secret")
+	os.Setenv("AWS_SECRET_KEY", "old_secret")
+
+	os.Setenv("AWS_ACCESS_KEY_ID", "access")
+	os.Setenv("AWS_ACCESS_KEY", "old_access")
+
+	os.Setenv("AWS_SESSION_TOKEN", "token")
+	os.Setenv("AWS_SECURITY_TOKEN", "old_token")
+
 	auth, err := aws.EnvAuth()
 	c.Assert(err, IsNil)
 	c.Assert(auth, Equals, aws.Auth{SecretKey: "secret", AccessKey: "access", Token: "token"})
@@ -171,9 +187,10 @@ func (s *S) TestEnvAuthAlt(c *C) {
 	os.Clearenv()
 	os.Setenv("AWS_SECRET_KEY", "secret")
 	os.Setenv("AWS_ACCESS_KEY", "access")
+	os.Setenv("AWS_SECURITY_TOKEN", "token")
 	auth, err := aws.EnvAuth()
 	c.Assert(err, IsNil)
-	c.Assert(auth, Equals, aws.Auth{SecretKey: "secret", AccessKey: "access"})
+	c.Assert(auth, Equals, aws.Auth{SecretKey: "secret", AccessKey: "access", Token: "token"})
 }
 
 func (s *S) TestGetAuthStatic(c *C) {


### PR DESCRIPTION
According to http://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs `AWS_SESSION_TOKEN` is recommended name for this variable.

The proposed change is adding support for the new variable `AWS_SESSION_TOKEN` and giving it priority over the deprecated one.

I've also added extra test for all deprecated variables.
