### PR TITLE
SharedAuth: use os/user to locate home directory instead of HOME

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -15,6 +15,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/user"
+	"path/filepath"
 
 	"github.com/vaughan0/go-ini"
 )
@@ -355,12 +357,14 @@ func SharedAuth() (auth Auth, err error) {
 
 	var credentialsFile = os.Getenv("AWS_CREDENTIAL_FILE")
 	if credentialsFile == "" {
-		var homeDir = os.Getenv("HOME")
-		if homeDir == "" {
-			err = errors.New("Could not get HOME")
+		// Don't hard-code HOME env var, on Windows it's USERPROFILE, HOME may not be defined
+		// Use os/user instead for platform consistency
+		usr, usrerr := user.Current()
+		if usrerr != nil {
+			err = errors.New("Could not get user home directory")
 			return
 		}
-		credentialsFile = homeDir + "/.aws/credentials"
+		credentialsFile = filepath.Join(usr.HomeDir, ".aws", "credentials")
 	}
 
 	file, err := ini.LoadFile(credentialsFile)


### PR DESCRIPTION
HOME isn't necessarily defined on Windows machines, per AWS docs %USERPROFILE% is the root used on that platform. For better compatibility don't manually use environment at all & use os/user package instead.