### PR TITLE
Allow S3 optional PUT headers to be omitted

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -269,6 +269,7 @@ func (b *Bucket) Head(path string) (*http.Response, error) {
 }
 
 // Put inserts an object into the S3 bucket.
+// contType and perm can be left blank to use the defaults
 //
 // See http://goo.gl/FEBPD for details.
 func (b *Bucket) Put(path string, data []byte, contType string, perm ACL) error {
@@ -278,6 +279,7 @@ func (b *Bucket) Put(path string, data []byte, contType string, perm ACL) error 
 
 /*
 PutHeader - like Put, inserts an object into the S3 bucket.
+perm can be left blank to use the default
 Instead of Content-Type string, pass in custom headers to override defaults.
 */
 func (b *Bucket) PutHeader(path string, data []byte, customHeaders map[string][]string, perm ACL) error {
@@ -287,11 +289,19 @@ func (b *Bucket) PutHeader(path string, data []byte, customHeaders map[string][]
 
 // PutReader inserts an object into the S3 bucket by consuming data
 // from r until EOF.
+// contType and perm can be left blank to use the defaults
 func (b *Bucket) PutReader(path string, r io.Reader, length int64, contType string, perm ACL) error {
+
 	headers := map[string][]string{
 		"Content-Length": {strconv.FormatInt(length, 10)},
-		"Content-Type":   {contType},
-		"x-amz-acl":      {string(perm)},
+	}
+
+	// Content-Type and x-amz-acl are optional
+	if contType != "" {
+		headers["Content-Type"] = []string{contType}
+	}
+	if perm != "" {
+		headers["x-amz-acl"] = []string{string(perm)}
 	}
 	req := &request{
 		method:  "PUT",
@@ -312,7 +322,10 @@ func (b *Bucket) PutReaderHeader(path string, r io.Reader, length int64, customH
 	headers := map[string][]string{
 		"Content-Length": {strconv.FormatInt(length, 10)},
 		"Content-Type":   {"application/text"},
-		"x-amz-acl":      {string(perm)},
+	}
+	// x-amz-acl is optional
+	if perm != "" {
+		headers["x-amz-acl"] = []string{string(perm)}
 	}
 
 	// Override with custom headers


### PR DESCRIPTION
In the S3 API for PUT Object, the "Content-Type" and "x-amz-acl" headers are not required but were mandatory in the goamz S3 implementation. I've made them optional as supported by the API.