### PR TITLE
fix signing with Temporary Security Credentials

### DIFF
--- a/route53/sign.go
+++ b/route53/sign.go
@@ -5,8 +5,9 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
-	"github.com/mitchellh/goamz/aws"
 	"time"
+
+	"github.com/mitchellh/goamz/aws"
 )
 
 var b64 = base64.StdEncoding
@@ -22,4 +23,7 @@ func sign(auth aws.Auth, path string, params map[string]string) {
 	header := fmt.Sprintf("AWS3-HTTPS AWSAccessKeyId=%s,Algorithm=HmacSHA256,Signature=%s",
 		auth.AccessKey, signature)
 	params["X-Amzn-Authorization"] = string(header)
+	if auth.Token != "" {
+		params["X-Amz-Security-Token"] = auth.Token
+	}
 }


### PR DESCRIPTION
When using Route 53, things were working perfectly when `aws.GetAuth` was passed credentials directly, or when it fell back to `aws.SharedAuth` or `aws.EnvAuth`. However, when I switched my app to using Temporary Security Credentials, `aws.GetAuth` would fall through to `aws.getInstanceCredentials` to get credentials for the instance's role. I kept getting the following error (whitespace added for readability):

```
Request failed, got status code: 403. Response:
<?xml version="1.0" ?>
<ErrorResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
    <Error>
        <Type>Sender</Type>
        <Code>InvalidClientTokenId</Code>
        <Message>The security token included in the request is invalid</Message>
    </Error>
    <RequestId>49ea8b24-c929-11e4-bdf8-2bd74b0c762c</RequestId>
</ErrorResponse>
```

It turns out that the requests were missing a header. Here's the relevant snippet from the [docs](http://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html#UsingTemporarySecurityCredentials):

> If you are signing your request using temporary security credentials, you must include the corresponding security token in your request by adding the `x-amz-security-token` header.

So, if the `aws.Auth` struct has a non-nil `Token`, it should be added in a `X-Amz-Security-Token` header. With this change, I was able to use Temporary Security Credentials just fine.