### PR TITLE
Add support for AWS_SESSION_TOKEN

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -403,6 +403,9 @@ func EnvAuth() (auth Auth, err error) {
 	}
 
 	auth.Token = os.Getenv("AWS_SECURITY_TOKEN")
+	if auth.Token == "" {
+		auth.Token = os.Getenv("AWS_SESSION_TOKEN")
+	}
 
 	if auth.AccessKey == "" {
 		err = errors.New("AWS_ACCESS_KEY_ID or AWS_ACCESS_KEY not found in environment")

--- a/aws/aws_test.go
+++ b/aws/aws_test.go
@@ -171,9 +171,10 @@ func (s *S) TestEnvAuthAlt(c *C) {
 	os.Clearenv()
 	os.Setenv("AWS_SECRET_KEY", "secret")
 	os.Setenv("AWS_ACCESS_KEY", "access")
+	os.Setenv("AWS_SESSION_TOKEN", "token")
 	auth, err := aws.EnvAuth()
 	c.Assert(err, IsNil)
-	c.Assert(auth, Equals, aws.Auth{SecretKey: "secret", AccessKey: "access"})
+	c.Assert(auth, Equals, aws.Auth{SecretKey: "secret", AccessKey: "access", Token: "token"})
 }
 
 func (s *S) TestGetAuthStatic(c *C) {


### PR DESCRIPTION
aws_session_token is the variable used by AWS to represent session tokens:

http://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs
http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/EnvironmentCredentials.html