### PR TITLE
Add GetPasswordData operation for EC2 instances

### DIFF
--- a/ec2/ec2_test.go
+++ b/ec2/ec2_test.go
@@ -2,6 +2,7 @@ package ec2_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/mitchellh/goamz/aws"
 	"github.com/mitchellh/goamz/ec2"
@@ -122,6 +123,22 @@ func (s *S) TestRequestSpotInstancesErrorWithoutXML(c *C) {
 	c.Assert(ec2err.Code, Equals, "")
 	c.Assert(ec2err.Message, Equals, "")
 	c.Assert(ec2err.RequestId, Equals, "")
+}
+
+func (s *S) TestGetPasswordDataExample(c *C) {
+	testServer.Response(200, nil, GetPasswordDataResponseExample)
+
+	resp, err := s.ec2.GetPasswordData("i-2574e22a")
+
+	req := testServer.WaitRequest()
+
+	c.Assert(req.Form["InstanceId.1"], DeepEquals, []string{"i-2574e22a"})
+
+	c.Assert(err, IsNil)
+	c.Assert(resp.RequestId, Equals, "59dbff89-35bd-4eac-99ed-be587EXAMPLE")
+	c.Assert(resp.InstanceId, Equals, "i-2574e22a")
+	c.Assert(resp.Timestamp, Equals, time.Date(2009, 10, 24, 15, 0, 0, 0, time.UTC))
+	c.Assert(resp.PasswordData, Equals, "TGludXggdmVyc2lvbiAyLjYuMTYteGVuVSAoYnVpbGRlckBwYXRjaGJhdC5hbWF6b25zYSkgKGdj")
 }
 
 func (s *S) TestRunInstancesExample(c *C) {

--- a/ec2/responses_test.go
+++ b/ec2/responses_test.go
@@ -1261,3 +1261,11 @@ var DeleteCustomerGatewayResponseExample = `
    <requestId>7a62c49f-347e-4fc4-9331-6e8eEXAMPLE</requestId>
    <return>true</return>
 </DeleteCustomerGatewayResponse>`
+
+var GetPasswordDataResponseExample = `
+<GetPasswordDataResponse xmlns="http://ec2.amazonaws.com/doc/2014-10-01/">
+  <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
+  <instanceId>i-2574e22a</instanceId>
+  <timestamp>2009-10-24T15:00:00.000Z</timestamp>
+  <passwordData>TGludXggdmVyc2lvbiAyLjYuMTYteGVuVSAoYnVpbGRlckBwYXRjaGJhdC5hbWF6b25zYSkgKGdj</passwordData>
+</GetPasswordDataResponse>`


### PR DESCRIPTION
## Description

This operation allows the user to obtain a copy of the auto-generated Administrator password for an instance running Windows, encrypted using the key-pair specified on instance launch.

A test has been added using the example from the documentation, but with the response updated to reflect the actual time format passed in current usage.
## Example usage

``` go
package main

import (
    "fmt"
    "github.com/mitchellh/goamz/aws"
    "github.com/mitchellh/goamz/ec2"
    "log"
)

func main() {
    auth, err := aws.EnvAuth()
    if err != nil {
        log.Fatal(err)
    }

    client := ec2.New(auth, aws.USEast)

    resp, err := client.GetPasswordData("i-7435208e")
    if err != nil {
        log.Fatal(err)
    }

    log.Print(fmt.Sprintf("%+v", resp))
}
```

Example output (password available):

```
015/03/21 12:42:50 &{RequestId:ae0976ec-bf3e-4f29-8b76-b2909b53b55a InstanceId:i-7435208e Timestamp:2015-03-21 16:39:38 +0000 UTC PasswordData:
c1jbhR3b7cApaiPX2X8BdqqGo0LlY3jsFL5ods3yrp86UXhznv1Ae3rlNjxAKVFJOCGcbnDkV1dWU1CkOrc1proiWKJVefQsNXSKfVf/GW5eq+jag0C2jG2LITeKoio8jovhVMqQvtxP+DC+p21XWfBwXAuF5shAG+ULvx6dj1/7HJuDdcJwkptEswvIg95HOyfx29h6gTMDx1JwEHGDasWTJzrUp7tGESl+6LPS7SRI5SlrE1RrNn/3tsJstBi5yLKb7MjKlCHf6FNJYrlt1eXcA3gSAeBB699UjhXv1M5x6SSqmVmLcNlPeFfoOBbZ8vKS458p7Zj00OF3GJvGpA==
}
```

Example output (password not yet available):

```
2015/03/21 12:39:09 &{RequestId:a3df9040-beae-413c-862d-7833eb5de5e7 InstanceId:i-7435208e Timestamp:2015-03-21 16:38:16 +0000 UTC PasswordData:}
```
