### PR TITLE
add ListHostedZonesByName to route53

### DIFF
--- a/route53/responses_test.go
+++ b/route53/responses_test.go
@@ -120,3 +120,33 @@ var ListHostedZonesExample = `<?xml version="1.0" encoding="utf-8"?>
     <IsTruncated>false</IsTruncated>
     <MaxItems>100</MaxItems>
 </ListHostedZonesResponse>`
+
+var ListHostedZonesByNameExample = `<?xml version="1.0" encoding="UTF-8"?>
+<ListHostedZonesByNameResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+   <HostedZones>
+      <HostedZone>
+         <Id>/hostedzone/Z222222VVVVVVV</Id>
+         <Name>example2.com.</Name>
+         <CallerReference>MyUniqueIdentifier2</CallerReference>
+         <Config>
+            <Comment>This is my second hosted zone.</Comment>
+            <PrivateZone>false</PrivateZone>
+         </Config>
+         <ResourceRecordSetCount>17</ResourceRecordSetCount>
+      </HostedZone>
+      <HostedZone>
+         <Id>/hostedzone/Z2682N5HXP0BZ4</Id>
+         <Name>example3.com.</Name>
+         <CallerReference>MyUniqueIdentifier3</CallerReference>
+         <Config>
+            <Comment>This is my third hosted zone.</Comment>
+            <PrivateZone>false</PrivateZone>
+         </Config>
+         <ResourceRecordSetCount>117</ResourceRecordSetCount>
+      </HostedZone>
+   </HostedZones>
+   <DNSName>example2.com</DNSName>
+   <HostedZoneId>Z222222VVVVVVV</HostedZoneId>
+   <IsTruncated>false</IsTruncated>
+   <MaxItems>2</MaxItems>
+</ListHostedZonesByNameResponse>`

--- a/route53/route53.go
+++ b/route53/route53.go
@@ -245,6 +245,38 @@ func (r *Route53) ListHostedZones(marker string, maxItems int) (*ListHostedZones
 	return out, err
 }
 
+type ListHostedZonesByNameResponse struct {
+	HostedZones      []HostedZone `xml:"HostedZones>HostedZone"`
+	DNSName          string       `xml:"DNSName"`
+	IsTruncated      bool         `xml:"IsTruncated"`
+	NextDNSName      string       `xml:"NextDNSName"`
+	NextHostedZoneId string       `xml:"NextHostedZoneId"`
+	MaxItems         int          `xml:"MaxItems"`
+}
+
+func (r *Route53) ListHostedZonesByName(dnsName string, hostedZoneId string, maxItems int) (*ListHostedZonesByNameResponse, error) {
+	values := url.Values{}
+
+	if dnsName != "" {
+		values.Add("dnsname", dnsName)
+	}
+
+	if hostedZoneId != "" {
+		values.Add("Hostedzoneid", hostedZoneId)
+	}
+
+	if maxItems != 0 {
+		values.Add("maxitems", strconv.Itoa(maxItems))
+	}
+
+	out := &ListHostedZonesByNameResponse{}
+	err := r.query("GET", fmt.Sprintf("/%s/hostedzonesbyname", APIVersion), values, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, err
+}
+
 type GetChangeResponse struct {
 	ChangeInfo ChangeInfo `xml:"ChangeInfo"`
 }

--- a/route53/route53.go
+++ b/route53/route53.go
@@ -262,7 +262,7 @@ func (r *Route53) ListHostedZonesByName(dnsName string, hostedZoneId string, max
 	}
 
 	if hostedZoneId != "" {
-		values.Add("Hostedzoneid", hostedZoneId)
+		values.Add("hostedzoneid", hostedZoneId)
 	}
 
 	if maxItems != 0 {

--- a/route53/route53_test.go
+++ b/route53/route53_test.go
@@ -176,6 +176,25 @@ func TestListHostedZones(t *testing.T) {
 	}
 }
 
+func TestListHostedZonesByName(t *testing.T) {
+	testServer := makeTestServer()
+	client := makeClient(testServer)
+	testServer.Response(200, nil, ListHostedZonesByNameExample)
+
+	resp, err := client.ListHostedZonesByName("example2.com", "Z2682N5HXP0BZ4", 0)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if resp.HostedZones[0].Name != "example2.com." {
+		t.Fatalf("bad: %v", resp)
+	}
+
+	if resp.HostedZones[1].Name != "example3.com." {
+		t.Fatalf("bad: %v", resp)
+	}
+}
+
 func decode(t *testing.T, r io.Reader, out interface{}) {
 	var buf1 bytes.Buffer
 	var buf2 bytes.Buffer


### PR DESCRIPTION
Hi, 

I've added method to route53 for below .

http://docs.aws.amazon.com/Route53/latest/APIReference/api-list-hosted-zones-by-name.html

We can get specific zone response by name.
