### PR TITLE
Add platform to EC2 instance type

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -300,6 +300,7 @@ type Instance struct {
 	AvailZone          string          `xml:"placement>availabilityZone"`
 	Tenancy            string          `xml:"placement>tenancy"`
 	PlacementGroupName string          `xml:"placement>groupName"`
+	Platform           string          `xml:"platform"`
 	State              InstanceState   `xml:"instanceState"`
 	Tags               []Tag           `xml:"tagSet>item"`
 	VpcId              string          `xml:"vpcId"`


### PR DESCRIPTION
Useful for getting the string `Windows` vs Linux which is just an empty string.
