### PR TITLE
add Content-Length header for multipart complete

### DIFF
--- a/s3/multi.go
+++ b/s3/multi.go
@@ -353,6 +353,9 @@ func (m *Multi) Complete(parts []Part) error {
 	}
 	sort.Sort(c.Parts)
 	data, err := xml.Marshal(&c)
+	headers := map[string][]string{
+		"Content-Length": {strconv.Itoa(len(data))},
+	}
 	if err != nil {
 		return err
 	}
@@ -361,6 +364,7 @@ func (m *Multi) Complete(parts []Part) error {
 			method:  "POST",
 			bucket:  m.Bucket.Name,
 			path:    m.Key,
+			headers: headers,
 			params:  params,
 			payload: bytes.NewReader(data),
 		}


### PR DESCRIPTION
I use this go s3 library for ceph s3 api. But when I finish multipart upload using "func (m *Multi) Complete(parts []Part)", s3 responsed http code 400. And python boto is OK for ceph s3 api. So I used wireshark to capture http packet from boto and goamz，boto has a "Content-Length" in request header, and aws's document also has a "Content-Length", header,
http://docs.aws.amazon.com/zh_cn/AmazonS3/latest/API/mpUploadComplete.html. Finally I added the header for  goamz, Complete(parts []Part) running well, and I think aws s3 is also compatible too.
