### PR TITLE
remove explicit type pointing during array initialization

### DIFF
--- a/autoscaling/autoscaling.go
+++ b/autoscaling/autoscaling.go
@@ -136,16 +136,16 @@ type Tag struct {
 }
 
 type LaunchConfiguration struct {
-	AssociatePublicIpAddress bool     `xml:"AssociatePublicIpAddress"`
-	IamInstanceProfile       string   `xml:"IamInstanceProfile"`
-	ImageId                  string   `xml:"ImageId"`
-	InstanceType             string   `xml:"InstanceType"`
-	KernelId                 string   `xml:"KernelId"`
-	KeyName                  string   `xml:"KeyName"`
-	SpotPrice                string   `xml:"SpotPrice"`
-	Name                     string   `xml:"LaunchConfigurationName"`
-	SecurityGroups           []string `xml:"SecurityGroups>member"`
-	UserData                 []byte   `xml:"UserData"`
+	AssociatePublicIpAddress bool                 `xml:"AssociatePublicIpAddress"`
+	IamInstanceProfile       string               `xml:"IamInstanceProfile"`
+	ImageId                  string               `xml:"ImageId"`
+	InstanceType             string               `xml:"InstanceType"`
+	KernelId                 string               `xml:"KernelId"`
+	KeyName                  string               `xml:"KeyName"`
+	SpotPrice                string               `xml:"SpotPrice"`
+	Name                     string               `xml:"LaunchConfigurationName"`
+	SecurityGroups           []string             `xml:"SecurityGroups>member"`
+	UserData                 []byte               `xml:"UserData"`
 	BlockDevices             []BlockDeviceMapping `xml:"BlockDeviceMappings>member"`
 }
 

--- a/autoscaling/autoscaling_test.go
+++ b/autoscaling/autoscaling_test.go
@@ -48,7 +48,7 @@ func (s *S) Test_CreateAutoScalingGroup(c *C) {
 		TerminationPolicies:     []string{"ClosestToNextInstanceHour", "OldestInstance"},
 		Name:                    "foobar",
 		Tags: []autoscaling.Tag{
-			autoscaling.Tag{
+			{
 				Key:   "foo",
 				Value: "bar",
 			},
@@ -79,7 +79,7 @@ func (s *S) Test_CreateLaunchConfiguration(c *C) {
 		KeyName:        "foobar",
 		Name:           "i-141421",
 		UserData:       "#!/bin/bash\necho Hello\n",
-		BlockDevices:   []autoscaling.BlockDeviceMapping{
+		BlockDevices: []autoscaling.BlockDeviceMapping{
 			{DeviceName: "/dev/sdb", VirtualName: "ephemeral0"},
 			{DeviceName: "/dev/sdc", SnapshotId: "snap-a08912c9", DeleteOnTermination: true},
 		},

--- a/ec2/ec2i_test.go
+++ b/ec2/ec2i_test.go
@@ -188,7 +188,7 @@ func (s *ClientTests) TestRegions(c *C) {
 			errs <- err
 		}(region)
 	}
-	for _ = range allRegions {
+	for range allRegions {
 		err := <-errs
 		if err != nil {
 			ec2_err, ok := err.(*ec2.Error)

--- a/ec2/sign.go
+++ b/ec2/sign.go
@@ -27,7 +27,7 @@ func sign(auth aws.Auth, method, path string, params map[string]string, host str
 	// from the natural order of the encoded value of key=value.
 	// Percent and equals affect the sorting order.
 	var keys, sarray []string
-	for k, _ := range params {
+	for k := range params {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)

--- a/elb/elb_test.go
+++ b/elb/elb_test.go
@@ -77,7 +77,7 @@ func (s *S) TestCreateLoadBalancer(c *C) {
 
 	options := elb.CreateLoadBalancer{
 		AvailZone: []string{"us-east-1a"},
-		Listeners: []elb.Listener{elb.Listener{
+		Listeners: []elb.Listener{{
 			InstancePort:     80,
 			InstanceProtocol: "http",
 			SSLCertificateId: "needToAddASSLCertToYourAWSAccount",

--- a/exp/sns/topic.go
+++ b/exp/sns/topic.go
@@ -43,7 +43,7 @@ func (sns *SNS) ListTopics(NextToken *string) (resp *ListTopicsResp, err error) 
 		params["NextToken"] = *NextToken
 	}
 	err = sns.query(params, resp)
-	for i, _ := range resp.Topics {
+	for i := range resp.Topics {
 		resp.Topics[i].SNS = sns
 	}
 	return

--- a/rds/rds_test.go
+++ b/rds/rds_test.go
@@ -383,27 +383,27 @@ func (s *S) Test_ModifyDBParameterGroup(c *C) {
 	options := rds.ModifyDBParameterGroup{
 		DBParameterGroupName: "mydbparamgroup3",
 		Parameters: []rds.Parameter{
-			rds.Parameter{
+			{
 				ApplyMethod:    "immediate",
 				ParameterName:  "character_set_server",
 				ParameterValue: "utf8",
 			},
-			rds.Parameter{
+			{
 				ApplyMethod:    "immediate",
 				ParameterName:  "character_set_client",
 				ParameterValue: "utf8",
 			},
-			rds.Parameter{
+			{
 				ApplyMethod:    "immediate",
 				ParameterName:  "character_set_results",
 				ParameterValue: "utf8",
 			},
-			rds.Parameter{
+			{
 				ApplyMethod:    "immediate",
 				ParameterName:  "collation_server",
 				ParameterValue: "utf8_unicode_ci",
 			},
-			rds.Parameter{
+			{
 				ApplyMethod:    "immediate",
 				ParameterName:  "collation_connection",
 				ParameterValue: "utf8_unicode_ci",

--- a/rds/responses_test.go
+++ b/rds/responses_test.go
@@ -585,7 +585,6 @@ var DescribeDBParameterGroupsExample = `
 </DescribeDBParameterGroupsResponse>
 `
 
-
 var DeleteDBParameterGroupExample = `
 <DeleteDBParameterGroupResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
   <ResponseMetadata>

--- a/route53/route53_test.go
+++ b/route53/route53_test.go
@@ -120,7 +120,7 @@ func TestChangeResourceRecordSets(t *testing.T) {
 	req := &ChangeResourceRecordSetsRequest{
 		Comment: "Test",
 		Changes: []Change{
-			Change{
+			{
 				Action: "CREATE",
 				Record: ResourceRecordSet{
 					Name:    "foo.hashicorp.com",

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -16,7 +16,6 @@ import (
 	"encoding/base64"
 	"encoding/xml"
 	"fmt"
-	"github.com/mitchellh/goamz/aws"
 	"io"
 	"io/ioutil"
 	"log"
@@ -27,6 +26,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/mitchellh/goamz/aws"
 )
 
 const debug = false
@@ -532,7 +533,7 @@ func (b *Bucket) List(prefix, delim, marker string, max int) (result *ListResp, 
 	return result, nil
 }
 
-// Returns a mapping of all key names in this bucket to Key objects
+// GetBucketContents returns a mapping of all key names in this bucket to Key objects
 func (b *Bucket) GetBucketContents() (*map[string]Key, error) {
 	bucket_contents := map[string]Key{}
 	prefix := ""

--- a/s3/s3i_test.go
+++ b/s3/s3i_test.go
@@ -270,7 +270,7 @@ func (s *ClientTests) TestRegions(c *C) {
 			errs <- err
 		}(region)
 	}
-	for _ = range aws.Regions {
+	for range aws.Regions {
 		err := <-errs
 		if err != nil {
 			s3_err, ok := err.(*s3.Error)


### PR DESCRIPTION
Hi,
This PR contains some improvements for:
- redundant variable declaration during for loop
- skip explicit type during array initialization
