### PR TITLE
remove terraform and packer mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@ This is a fork of [https://launchpad.net/goamz](https://launchpad.net/goamz)
 that adds some missing API calls to certain packages.
 
 This library is *incomplete*, but implements a large amount of the AWS API.
-It is heavily used in projects such as
-[Terraform](https://github.com/hashicorp/terraform) and
-[Packer](https://github.com/mitchellh/packer). 
 If you find anything missing from this library, 
 please [file an issue](https://github.com/mitchellh/goamz).
 


### PR DESCRIPTION
Since they don't use the library anymore.